### PR TITLE
use `auto-download` for snapshots for sync check

### DIFF
--- a/scripts/sync_check/docker-compose.yml
+++ b/scripts/sync_check/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - 'mainnet'
       - '--config'
       - ${FOREST_TARGET_SCRIPTS}/sync_check.toml
+      - '--auto-download-snapshot'
     restart: unless-stopped
     labels:
       com.centurylinklabs.watchtower.enable: true
@@ -42,6 +43,7 @@ services:
       - 'calibnet'
       - '--config'
       - ${FOREST_TARGET_SCRIPTS}/sync_check.toml
+      - '--auto-download-snapshot'
     restart: unless-stopped
     labels:
       com.centurylinklabs.watchtower.enable: true
@@ -78,6 +80,8 @@ services:
       - |
         ruby ${FOREST_TARGET_SCRIPTS}/sync_check.rb forest-mainnet &
         ruby ${FOREST_TARGET_SCRIPTS}/sync_check.rb forest-calibnet &
+        wait
+        rm -rf ${FOREST_TARGET_DATA}/snapshots
         sleep infinity
     depends_on:
       - forest_mainnet

--- a/scripts/sync_check/health_check.sh
+++ b/scripts/sync_check/health_check.sh
@@ -37,11 +37,12 @@ function update_metrics() {
 }
 
 # Checks if an error occurred and is visible in the metrics.
-# Arg: name of the error metric
+# Arg 1: name of the error metric
+# Arg 2: maximum number of occurrences for the assertion to pass (0 for strictly not pass)
 function assert_error() {
   errors="$(get_metric_value "$1")"
-  if [ -n "$errors" ]; then
-    echo "❌ $1: $errors"
+  if [[ "$errors" -gt "$2" ]]; then
+    echo "❌ $1: $errors (max: $2)"
     ret=$RET_SYNC_ERROR
   fi
 }
@@ -89,10 +90,10 @@ else
 fi
 
 # Assert there are no sync errors
-assert_error "network_head_evaluation_errors"
-assert_error "bootstrap_errors"
-assert_error "follow_network_interruptions"
-assert_error "follow_network_errors"
+assert_error "network_head_evaluation_errors" 0
+assert_error "bootstrap_errors" 2
+assert_error "follow_network_interruptions" 0
+assert_error "follow_network_errors" 0
 
 if [ "$ret" -ne "$RET_SYNC_ERROR" ]; then
   echo "✅ No sync errors"

--- a/scripts/sync_check/sync_check_process.rb
+++ b/scripts/sync_check/sync_check_process.rb
@@ -57,26 +57,9 @@ class SyncCheck
     Dir.glob("#{FOREST_DATA}/snapshots/#{network}/*.car")[0] or raise "Can't find snapshot in #{dir}"
   end
 
-  # Imports the snapshots
-  def import_snapshots
-    @logger.info 'Importing snapshots'
-    run_forest '--chain calibnet --halt-after-import --auto-download-snapshot'
-    run_forest '--chain mainnet --halt-after-import --auto-download-snapshot'
-  end
-
-  # Deletes all snapshots to free up memory.
-  def delete_snapshots
-    @logger.info 'Deleting snapshots'
-    run_forest_cli '--chain calibnet snapshot clean --force'
-    run_forest_cli '--chain mainnet snapshot clean --force'
-  end
-
-  # Starts docker-compose services. It first downloads and imports the snapshots.
+  # Starts docker-compose services.
   def start_services
     @logger.info 'Starting services'
-    import_snapshots
-    delete_snapshots
-
     `docker-compose up --build --force-recreate --detach`
     raise 'Failed to start services' unless $CHILD_STATUS.success?
   end
@@ -116,7 +99,7 @@ class SyncCheck
   def run
     loop do
       begin
-        cleanup unless disk_usage < 0.8
+        cleanup unless disk_usage < 0.9
         start_services unless services_up?
       rescue StandardError => e
         report_error e

--- a/scripts/sync_check/sync_check_process.rb
+++ b/scripts/sync_check/sync_check_process.rb
@@ -52,13 +52,6 @@ class SyncCheck
     1 - stat.blocks_available.fdiv(stat.blocks)
   end
 
-  # Downloads snapshots from trusted sources.
-  def download_snapshots
-    @logger.info 'Downloading snapshots'
-    run_forest_cli '--chain calibnet snapshot fetch'
-    run_forest_cli '--chain mainnet snapshot fetch'
-  end
-
   # Retrieves path to the relevant snapshot based on the network chosen.
   def snapshot_path(network)
     Dir.glob("#{FOREST_DATA}/snapshots/#{network}/*.car")[0] or raise "Can't find snapshot in #{dir}"
@@ -67,8 +60,8 @@ class SyncCheck
   # Imports the snapshots
   def import_snapshots
     @logger.info 'Importing snapshots'
-    run_forest "--chain calibnet --halt-after-import --import-snapshot #{snapshot_path('calibnet')}"
-    run_forest "--chain mainnet --halt-after-import --import-snapshot #{snapshot_path('mainnet')}"
+    run_forest '--chain calibnet --halt-after-import --auto-download-snapshot'
+    run_forest '--chain mainnet --halt-after-import --auto-download-snapshot'
   end
 
   # Deletes all snapshots to free up memory.
@@ -81,7 +74,6 @@ class SyncCheck
   # Starts docker-compose services. It first downloads and imports the snapshots.
   def start_services
     @logger.info 'Starting services'
-    download_snapshots
     import_snapshots
     delete_snapshots
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- this is a workaround for https://github.com/docker/compose/issues/6975; if we lose the volume, we re-download it. It's not ideal, but hopefully, https://github.com/ChainSafe/forest-iac/issues/42 will mitigate the issue altogether.
- allow for few bootstrap errors before failing the sync check. I guess on calibnet it can happen from time to time.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->