### PR TITLE
feat: basic terraform-ification of the daily snapshot service

### DIFF
--- a/daily_snapshot_terraform/.gitignore
+++ b/daily_snapshot_terraform/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+local-terraform.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/daily_snapshot_terraform/calibnet/Makefile
+++ b/daily_snapshot_terraform/calibnet/Makefile
@@ -1,0 +1,11 @@
+init:
+	@terraform init
+
+plan:
+	@terraform plan -var-file="terraform.tfvars"
+
+apply:
+	@terraform apply -var-file="terraform.tfvars" --auto-approve
+
+destroy:
+	@terraform destroy -var-file="terraform.tfvars"

--- a/daily_snapshot_terraform/calibnet/main.tf
+++ b/daily_snapshot_terraform/calibnet/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  backend "s3" {
+    bucket = "forest-iac"
+    key = "daily_snapshot_calibnet.tfstate"
+    # This value is completely unused by DO but _must_ be a known AWS region.
+    region = "us-west-1" 
+    # The S3 region is determined by the endpoint. fra1 = Frankfurt.
+    # This region does not have to be shared by the droplet.
+    endpoint = "https://fra1.digitaloceanspaces.com"
+
+    # For reasons, Terraform cannot validate DO credentials.
+    skip_credentials_validation = "true"
+  }
+}
+
+module "daily_snapshot" {
+	source = "../modules/daily_snapshot"
+
+  name = "test-forest-snapshot-calibnet"
+  size = "s-4vcpu-8gb"
+
+  new_key_ssh_key_fingerprint = var.new_key_ssh_key_fingerprint
+  digitalocean_token = var.digitalocean_token
+}
+
+output "ip" {
+  value = [module.daily_snapshot.ip]
+}
+
+output "files" {
+  value = [module.daily_snapshot.files]
+}

--- a/daily_snapshot_terraform/calibnet/terraform.tfvars
+++ b/daily_snapshot_terraform/calibnet/terraform.tfvars
@@ -1,0 +1,3 @@
+# This set of variables are unique and must be defined here in order to deploy successfully
+new_key_ssh_key_fingerprint = "99:ea:ec:bf:9f:d1:b2:52:02:b2:78:a2:57:25:a0:e7"
+digitalocean_token = "dop_v1_275b6e7a6e909d007d0abea4f6986f0c3a22052c78a97faf6bee1b90e802ca32"

--- a/daily_snapshot_terraform/calibnet/variable.tf
+++ b/daily_snapshot_terraform/calibnet/variable.tf
@@ -1,0 +1,9 @@
+variable "digitalocean_token" {
+  description = "Token for authentication."
+  type        = string
+}
+
+variable "new_key_ssh_key_fingerprint" {
+  description = "the ssh key fingerprint for digitalocean"
+  type        = string
+}

--- a/daily_snapshot_terraform/modules/daily_snapshot/main.tf
+++ b/daily_snapshot_terraform/modules/daily_snapshot/main.tf
@@ -1,0 +1,124 @@
+
+terraform {
+  required_version = "~> 1.3"
+
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "digitalocean" {
+  token = var.digitalocean_token
+}
+
+// Ugly hack because 'archive_file' cannot mix files and folders.
+data "external" "sources_zip" {
+  program = ["sh", "${path.module}/prep_sources.sh", "${path.module}"]
+}
+
+data "local_file" "sources" {
+  filename = "${path.module}/sources.zip"
+}
+
+// Note: The init.sh file is also included in the sources.zip such that the hash
+// of the archive captures the entire state of the machine.
+data "local_file" "init" {
+  filename = "${path.module}/init.sh"
+}
+
+resource "digitalocean_droplet" "forest" {
+  image  = var.image
+  name   = var.name
+  region = var.region
+  size   = var.size
+  # Re-initialize resource if this hash changes:
+  user_data = data.local_file.sources.content_sha256
+  tags   = ["iac"]
+  backups = var.backups
+  ssh_keys = [var.new_key_ssh_key_fingerprint]
+
+  connection {
+    host = self.ipv4_address
+    user = "root"
+    type = "ssh"
+  }
+
+  provisioner "file" {
+    source      = data.local_file.sources.filename
+    destination = "/root/sources.zip"
+  }
+
+  provisioner "file" {
+    source      = data.local_file.init.filename
+    destination = "/root/init.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cd /root/",
+      "nohup sh ./init.sh"
+    ]
+  }
+}
+
+data "digitalocean_project" "forest_project" {
+  name = "Forest-DEV"
+}
+
+resource "digitalocean_project_resources" "connect_forest_project" {
+  project = data.digitalocean_project.forest_project.id
+  resources = [ digitalocean_droplet.forest.urn ]
+}
+
+resource "digitalocean_firewall" "forest-firewalls-test" {
+  name = var.name
+
+  inbound_rule {
+    protocol              = "tcp"
+    port_range            = "22"
+    source_addresses      = var.source_addresses
+  }
+
+  inbound_rule {
+    protocol              = "tcp"
+    port_range            = "1234"
+    source_addresses      = var.source_addresses
+  }
+
+  inbound_rule {
+    protocol              = "tcp"
+    port_range            = "80"
+    source_addresses      = var.source_addresses
+  }
+
+  inbound_rule {
+    protocol              = "udp"
+    port_range            = "53"
+    source_addresses      = var.source_addresses
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "all"
+    destination_addresses = var.destination_addresses
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "53"
+    destination_addresses = var.destination_addresses
+  }
+
+droplet_ids = [digitalocean_droplet.forest.id]
+}
+
+output "ip" {
+  value = [digitalocean_droplet.forest.ipv4_address]
+}
+
+output "files" {
+  value = ""
+}

--- a/daily_snapshot_terraform/modules/daily_snapshot/prep_sources.sh
+++ b/daily_snapshot_terraform/modules/daily_snapshot/prep_sources.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Copy local source files in a folder together with ruby_common and create a zip archive.
+
+cd $1
+mkdir sources 2> /dev/null
+cp -r ../../../scripts/ruby_common service/
+
+(cd service; zip -r -X ../sources.zip * \
+    %1>/dev/null %2>/dev/null)
+rm -fr sources/ruby_common
+echo "{ \"path\": \"$1/sources.zip\" }"

--- a/daily_snapshot_terraform/modules/daily_snapshot/service/daily_snapshot.rb
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/daily_snapshot.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative 'ruby_common/slack_client'
+require_relative 'ruby_common/docker_utils'
+require_relative 'ruby_common/utils'
+require_relative 'snapshots_prune'
+
+require 'date'
+require 'logger'
+require 'fileutils'
+require 'active_support/time'
+
+BASE_FOLDER = get_and_assert_env_variable 'BASE_FOLDER'
+SLACK_TOKEN = get_and_assert_env_variable 'SLACK_API_TOKEN'
+CHANNEL = get_and_assert_env_variable 'SLACK_NOTIF_CHANNEL'
+
+CHAIN_NAME = ARGV[0]
+raise 'No chain name supplied. Please provide chain identifier, e.g. calibnet or mainnet' if ARGV.empty?
+
+# Current datetime, to append to the log files
+DATE = Time.new.strftime '%FT%H:%M:%S'
+LOG_EXPORT = "#{CHAIN_NAME}_#{DATE}_export"
+
+SNAPSHOTS_DIR = File.join(BASE_FOLDER, 's3', CHAIN_NAME)
+
+loop do
+  client = SlackClient.new CHANNEL, SLACK_TOKEN
+
+  # Find the snapshot with the most recent modification date
+  latest = Dir.glob(File.join(SNAPSHOTS_DIR, '/*.car')).max_by { |f| File.mtime(f) }
+
+  # Check if the date of the most recent snapshot is today
+  if Time.new.to_date == File.stat(latest).mtime.to_date
+    # We already have a snapshot for today. Do nothing.
+    puts "No snapshot required for #{CHAIN_NAME}"
+  else
+    puts 'New snapshot required'
+
+    # Sync and export snapshot
+    snapshot_uploaded = system("bash upload_snapshot.sh #{CHAIN_NAME} #{latest} > #{LOG_EXPORT} 2>&1")
+
+    if snapshot_uploaded
+      client.post_message "✅ Snapshot uploaded for #{CHAIN_NAME}. 🌲🌳🌲🌳🌲"
+    else
+      client.post_message "⛔ Snapshot failed for #{CHAIN_NAME}. 🔥🌲🔥 "
+    end
+
+    # attach the log file and print the contents to STDOUT
+    client.attach_files(LOG_EXPORT)
+    puts "Snapshot export log:\n#{File.read(LOG_EXPORT)}"
+
+    # Prune snapshots
+    pruned = prune_snapshots(SNAPSHOTS_DIR)
+    client.attach_comment("Pruned snapshots: `#{pruned.join(', ')}`") unless pruned.empty?
+  end
+
+  # Loop such that a new snapshot will be updated once per day.
+  sleep(1.hour)
+end

--- a/daily_snapshot_terraform/modules/daily_snapshot/service/init.sh
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/init.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "script is running" > output.txt
+apt-get install unzip
+unzip -o sources.zip

--- a/daily_snapshot_terraform/modules/daily_snapshot/service/snapshots_prune.rb
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/snapshots_prune.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'pathname'
+
+# Class representing a snapshot bucket with a defined number of entries.
+class SnapshotBucket
+  def initialize(max_entries = nil)
+    @max_entries = max_entries
+    @entries = Set.new
+  end
+
+  # Adds an entry to the bucket unless it is already full or already contains the key.
+  # Return false on insert failure.
+  def add?(entry)
+    return false if !@max_entries.nil? && @entries.size >= @max_entries
+
+    !@entries.add?(entry).nil?
+  end
+end
+
+# Represents Day Bucket. They key is the date.
+class DayBucket < SnapshotBucket
+  def add?(entry)
+    super File.mtime(entry).to_date
+  end
+end
+
+# Represents Weeks Bucket. The key is "WWYY" (week starts on Monday).
+class WeeksBucket < SnapshotBucket
+  def add?(entry)
+    super File.mtime(entry).to_date.strftime('%m%y')
+  end
+end
+
+# Represents Months Bucket. The key is "MMYY"
+class MonthsBucket < SnapshotBucket
+  def add?(entry)
+    super File.mtime(entry).to_date.strftime('%m%y')
+  end
+end
+
+# Prunes snapshots directory with the following retention policy:
+# * keep all snapshots generated in the last 7 days,
+# * keep one snapshot per week for the last 4 weeks,
+# * keep one snapshot per month after 4 weeks.
+#
+# Returns pruned snapshots' filenames.
+def prune_snapshots(snapshots_directory)
+  day_bucket = DayBucket.new 7
+  weeks_bucket = WeeksBucket.new 4
+  months_bucket = MonthsBucket.new
+  buckets = [day_bucket, weeks_bucket, months_bucket]
+
+  # iterate over each entry and try to add it to the buckets, newest first.
+  Dir.glob(File.join(snapshots_directory, '*.car'))
+     .sort_by { |f| File.mtime(f) }
+     .reverse
+     .reject  { |f| buckets.any? { |bucket| bucket.add? f } }
+     .each    { |f| remove_snapshot f }
+end
+
+# Removes the snapshot and optionally the related checksum file if it exists.
+def remove_snapshot(snapshot)
+  checksum = Pathname.new(snapshot).sub_ext('.sha256sum')
+  File.delete checksum if checksum.file?
+  File.delete snapshot
+end

--- a/daily_snapshot_terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# If Forest hasn't synced to the network after 90 minutes, something has gone wrong.
+SYNC_TIMEOUT=90m
+
+if [[ $# != 2 ]]; then
+  echo "Usage: bash $0 CHAIN_NAME SNAPSHOT_PATH"
+  exit 1
+fi
+
+CHAIN_NAME=$1
+NEWEST_SNAPSHOT=$2
+
+# Make sure we have the most recent Forest image
+docker pull ghcr.io/chainsafe/forest:"${FOREST_TAG}"
+
+# Ensure that we can access files with the default Forest image user
+SNAPSHOTS_DIR=$BASE_FOLDER/s3/$CHAIN_NAME
+
+permission=$(stat -c "%a" "$SNAPSHOTS_DIR")
+if ! ((permission & 7)); then
+  echo "The snapshots directory is not accessible by everyone to read and write. Adding necessary permissions"
+  chmod o+rwx "$SNAPSHOTS_DIR"
+else
+  echo "Snapshots directory permissions OK"
+fi
+
+permission=$(stat -c "%a" "$NEWEST_SNAPSHOT")
+if ! ((permission & 4)); then
+  echo "Snapshot not readable for everyone. Adding necessary permissions."
+  chmod o+r "$NEWEST_SNAPSHOT"
+else
+  echo "Latest snapshot permissions OK"
+fi
+
+# Sync and export is done in a single container to make sure everything is
+# properly cleaned up.
+COMMANDS=$(cat << HEREDOC
+echo "Chain: $CHAIN_NAME"
+echo "Snapshot: $NEWEST_SNAPSHOT"
+forest --encrypt-keystore false --chain $CHAIN_NAME --import-snapshot $NEWEST_SNAPSHOT --detach || { echo "failed starting forest daemon"; exit 1; }
+timeout $SYNC_TIMEOUT forest-cli --chain $CHAIN_NAME sync wait || { echo "timed-out on forest-cli sync"; exit 1; }
+cat forest.err forest.out
+forest-cli --chain $CHAIN_NAME snapshot export || { echo "failed to export the snapshot"; exit 1; }
+mv ./forest_snapshot* $SNAPSHOTS_DIR/
+HEREDOC
+)
+
+docker run \
+  --name forest-snapshot-upload-node \
+  --rm \
+  -v "$BASE_FOLDER":"$BASE_FOLDER":rshared \
+  --entrypoint /bin/bash \
+  ghcr.io/chainsafe/forest:"${FOREST_TAG}" \
+  -c "$COMMANDS"

--- a/daily_snapshot_terraform/modules/daily_snapshot/variable.tf
+++ b/daily_snapshot_terraform/modules/daily_snapshot/variable.tf
@@ -1,0 +1,49 @@
+variable "digitalocean_token" {
+  description = "Token for authentication."
+  type        = string
+}
+
+variable "name" {
+  description = "The name of Forest Droplet"
+  type        = string
+}
+
+variable "size" {
+  description = "The size of the droplet instance to launch"
+  type        = string
+}
+
+variable "new_key_ssh_key_fingerprint" {
+  description = "the ssh key fingerprint for digitalocean"
+  type        = string
+}
+
+variable "image" {
+  description = "The ID of the AMI to use for the Droplet"
+  type        = string
+  default     = "docker-20-04"
+}
+
+variable "region" {
+  description = "The region where resources will be created"
+  type        = string
+  default     = "fra1"
+}
+
+variable "backups" {
+  description = "A boolean flag indicating whether to enable backups"
+  type        = string
+  default     = false
+}
+
+variable "source_addresses" {
+  description = "List of source addresses."
+  type        = list(string)
+  default     = ["0.0.0.0/0", "::/0"]
+}
+
+variable "destination_addresses" {
+  description = "List of destination addresses."
+  type        = list(string)
+  default     = ["0.0.0.0/0", "::/0"]
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Terraform files for the daily snapshot service, allow it to be automatically deployed.

Key features:
- Automatic re-deployment when setting change (droplet name, size, volumes, etc).
- Automatic re-deployment when the service scripts change.
- The droplet is automatically attached to the `Forest-DEV` project in DO.
- Changing secrets (which contain S3 credentials and Slack tokens) does not automatically trigger a re-deployment. In this case, manually triggering the deployment workflow is required.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->