### PR TITLE
feat(sync_check): trigger GC more eagerly to reduce disk usage capacity requirement

### DIFF
--- a/scripts/sync_check/docker-compose.yml
+++ b/scripts/sync_check/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - '--config'
       - ${FOREST_TARGET_SCRIPTS}/sync_check.toml
       - '--auto-download-snapshot'
+    environment:
+      FOREST_GC_TRIGGER_FACTOR: "1.4"
     restart: unless-stopped
     labels:
       com.centurylinklabs.watchtower.enable: true
@@ -44,6 +46,8 @@ services:
       - '--config'
       - ${FOREST_TARGET_SCRIPTS}/sync_check.toml
       - '--auto-download-snapshot'
+    environment:
+      FOREST_GC_TRIGGER_FACTOR: "1.2"
     restart: unless-stopped
     labels:
       com.centurylinklabs.watchtower.enable: true


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- The default `FACTOR` is 2.0, so the estimated disk usage capacity is abt 120 + 160 + 20 = 300GB. By setting it to 1.4, it's abt 120 + 120 = 240.
- Use 1.2 on calibnet to trigger GC even more eagerly since it takes only 1-2min



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->