### PR TITLE
fix: only deploy services when something has changed

### DIFF
--- a/daily_snapshot_terraform/modules/daily_snapshot/main.tf
+++ b/daily_snapshot_terraform/modules/daily_snapshot/main.tf
@@ -21,12 +21,12 @@ provider "digitalocean" {
 }
 
 // Ugly hack because 'archive_file' cannot mix files and folders.
-data "external" "sources_zip" {
+data "external" "sources_tar" {
   program = ["sh", "${path.module}/prep_sources.sh", "${path.module}"]
 }
 
 data "local_file" "sources" {
-  filename = data.external.sources_zip.result.path
+  filename = data.external.sources_tar.result.path
 }
 
 // Note: The init.sh file is also included in the sources.zip such that the hash
@@ -51,17 +51,10 @@ resource "digitalocean_droplet" "forest" {
     type = "ssh"
   }
 
-  # Push the sources.zip file to the newly booted droplet
+  # Push the sources.tar file to the newly booted droplet
   provisioner "file" {
     source      = data.local_file.sources.filename
-    destination = "/root/sources.zip"
-  }
-
-  # Push the init script separately because the droplet doesn't have unzip
-  # installed yet.
-  provisioner "file" {
-    source      = data.local_file.init.filename
-    destination = "/root/init.sh"
+    destination = "/root/sources.tar"
   }
 
   # WARNING: Changing these commands will _not_ trigger a re-deployment. If you
@@ -69,6 +62,7 @@ resource "digitalocean_droplet" "forest" {
   provisioner "remote-exec" {
     inline = [
       "cd /root/",
+      "tar xf sources.tar",
       # Set required environment variables
       "export AWS_ACCESS_KEY_ID=${var.AWS_ACCESS_KEY_ID}",
       "export AWS_SECRET_ACCESS_KEY=${var.AWS_SECRET_ACCESS_KEY}",

--- a/daily_snapshot_terraform/modules/daily_snapshot/prep_sources.sh
+++ b/daily_snapshot_terraform/modules/daily_snapshot/prep_sources.sh
@@ -3,8 +3,9 @@
 # Copy local source files in a folder together with ruby_common and create a zip archive.
 
 cd "$1" || exit
-cp -r ../../../scripts/ruby_common service/
+cp --archive ../../../scripts/ruby_common service/
 
-(cd service && zip -r -X ../sources.zip . > /dev/null 2>&1)
+rm -f sources.tar
+(cd service && tar cf ../sources.tar * --sort=name --mtime='UTC 2019-01-01' > /dev/null 2>&1)
 rm -fr service/ruby_common
-echo "{ \"path\": \"$1/sources.zip\" }"
+echo "{ \"path\": \"$1/sources.tar\" }"

--- a/daily_snapshot_terraform/modules/daily_snapshot/prep_sources.sh
+++ b/daily_snapshot_terraform/modules/daily_snapshot/prep_sources.sh
@@ -6,6 +6,6 @@ cd "$1" || exit
 cp --archive ../../../scripts/ruby_common service/
 
 rm -f sources.tar
-(cd service && tar cf ../sources.tar * --sort=name --mtime='UTC 2019-01-01' > /dev/null 2>&1)
+(cd service && tar cf ../sources.tar ./* --sort=name --mtime='UTC 2019-01-01' > /dev/null 2>&1)
 rm -fr service/ruby_common
 echo "{ \"path\": \"$1/sources.tar\" }"

--- a/daily_snapshot_terraform/modules/daily_snapshot/service/init.sh
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/init.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-dnf install -y docker docker-compose ruby ruby-devel make gcc s3fs-fuse unzip
+dnf install -y docker docker-compose ruby ruby-devel make gcc s3fs-fuse
 gem install docker-api slack-ruby-client activesupport
 
 systemctl start docker
-
-unzip -o sources.zip
 
 export BASE_FOLDER=/root/
 export FOREST_TAG=latest


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- The terraform module was configured to only re-deploy when the hash of a zip-file changed. Unfortunately, I messed up and the hash would depend on the current time (thus always be unique). Now I'm using a tarball without modification times and it works as intended.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->