### PR TITLE
feat: initiate droplets with ssh fingerprints from the entire ChainSafe team

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,6 @@ jobs:
     env:
       TF_VAR_do_token: ${{ secrets.DO_TOKEN }}
       TF_VAR_slack_token: ${{ secrets.SLACK_TOKEN }}
-      # Fingerprint of the key used by this workflow. This SSH key is only used
-      # by the forest-iac repository and can be fetched from 1password
-      TF_VAR_ssh_fingerprint: ${{ secrets.SSH_FINGERPRINT }}
       # S3 access keys used by the snapshot service
       TF_VAR_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       TF_VAR_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/daily_snapshot_terraform/calibnet/README.md
+++ b/daily_snapshot_terraform/calibnet/README.md
@@ -35,8 +35,6 @@ you don't set these variables):
 export TF_VAR_do_token=
 # Slack access token: https://api.slack.com/apps
 export TF_VAR_slack_token=
-# Fingerprint of SSH key registered with DigitalOcean: https://cloud.digitalocean.com/account/security
-export TF_VAR_ssh_fingerprint=
 # S3 access keys used by the snapshot service. Can be generated here: https://cloud.digitalocean.com/account/api/spaces
 export TF_VAR_AWS_ACCESS_KEY_ID=
 export TF_VAR_AWS_SECRET_ACCESS_KEY=
@@ -45,8 +43,10 @@ export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=
 ```
 
-Forest tokens can be found on 1password. The SSH fingerprint needs to be
-registered with Digital Ocean.
+Forest tokens can be found on 1password.
+
+You also need to register your public key with Digital Ocean. This can be done
+here: https://cloud.digitalocean.com/account/security
 
 To prepare terraform for other commands:
 ```bash

--- a/daily_snapshot_terraform/calibnet/main.tf
+++ b/daily_snapshot_terraform/calibnet/main.tf
@@ -37,7 +37,6 @@ module "daily_snapshot" {
   slack_token           = var.slack_token
   AWS_ACCESS_KEY_ID     = var.AWS_ACCESS_KEY_ID
   AWS_SECRET_ACCESS_KEY = var.AWS_SECRET_ACCESS_KEY
-  ssh_fingerprint       = var.ssh_fingerprint
   digitalocean_token    = var.do_token
 }
 

--- a/daily_snapshot_terraform/calibnet/variable.tf
+++ b/daily_snapshot_terraform/calibnet/variable.tf
@@ -3,11 +3,6 @@ variable "do_token" {
   type        = string
 }
 
-variable "ssh_fingerprint" {
-  description = "the ssh key fingerprint for digitalocean"
-  type        = string
-}
-
 variable "AWS_ACCESS_KEY_ID" {
   description = "S3 access key id"
   type        = string

--- a/daily_snapshot_terraform/modules/daily_snapshot/main.tf
+++ b/daily_snapshot_terraform/modules/daily_snapshot/main.tf
@@ -35,6 +35,13 @@ data "local_file" "init" {
   filename = "${path.module}/service/init.sh"
 }
 
+data "digitalocean_ssh_keys" "keys" {
+  sort {
+    key       = "name"
+    direction = "asc"
+  }
+}
+
 resource "digitalocean_droplet" "forest" {
   image  = var.image
   name   = var.name
@@ -43,7 +50,7 @@ resource "digitalocean_droplet" "forest" {
   # Re-initialize resource if this hash changes:
   user_data = data.local_file.sources.content_sha256
   tags      = ["iac"]
-  ssh_keys  = [var.ssh_fingerprint]
+  ssh_keys  = data.digitalocean_ssh_keys.keys.ssh_keys.*.fingerprint
 
   connection {
     host = self.ipv4_address

--- a/daily_snapshot_terraform/modules/daily_snapshot/variable.tf
+++ b/daily_snapshot_terraform/modules/daily_snapshot/variable.tf
@@ -13,11 +13,6 @@ variable "size" {
   type        = string
 }
 
-variable "ssh_fingerprint" {
-  description = "the ssh key fingerprint for digitalocean"
-  type        = string
-}
-
 variable "slack_channel" {
   description = "slack channel name for notifications"
   type        = string


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Initiate new droplets with SSH fingerprints for everyone who has write-access to our DO account.

This makes it easier for all of us to log into a running droplet. However, it also grants access to, say, Priom (who's head of devops at ChainSafe) even though he's not a member of the Forest team. I think that is fine. Even before adding his key, he could access our droplets through the Droplet Console.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->