### PR TITLE
feat(sync_check): save admin token to a temp file

### DIFF
--- a/scripts/sync_check/docker-compose.yml
+++ b/scripts/sync_check/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - '--config'
       - ${FOREST_TARGET_SCRIPTS}/sync_check.toml
       - '--auto-download-snapshot'
+      - '--save-token'
+      - '/tmp/admin_token'
     environment:
       FOREST_GC_TRIGGER_FACTOR: "1.4"
     restart: unless-stopped
@@ -46,6 +48,8 @@ services:
       - '--config'
       - ${FOREST_TARGET_SCRIPTS}/sync_check.toml
       - '--auto-download-snapshot'
+      - '--save-token'
+      - '/tmp/admin_token'
     environment:
       FOREST_GC_TRIGGER_FACTOR: "1.2"
     restart: unless-stopped


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Save admin token to `/tmp/admin_token` in sync check containers to make it easier to manually execute `forest-cli` commands that require admin permissions



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->