### PR TITLE
fix: fail if snapshot generation takes longer than 24 hours

### DIFF
--- a/daily_snapshot_terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -2,6 +2,7 @@
 
 # If Forest hasn't synced to the network after 8 hours, something has gone wrong.
 SYNC_TIMEOUT=8h
+DOCKER_TIMEOUT=24h
 
 if [[ $# != 2 ]]; then
   echo "Usage: bash $0 CHAIN_NAME SNAPSHOT_PATH"
@@ -33,7 +34,7 @@ HEREDOC
 )
 
 # Run forest and generate a snapshot in forest_db/
-docker run \
+timeout $DOCKER_TIMEOUT docker run \
   --name forest-snapshot-upload-node-"$CHAIN_NAME" \
   --rm \
   -v "$BASE_FOLDER/forest_db:/home/forest/forest_db":z \


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Forest got stuck in an infinite loop while generating a calibnet snapshot. The root cause hasn't been found but the snapshot service shouldn't be bricked when Forest is misbehaving.
- Install a hard limit of 24 hours when generating snapshots.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->