### PR TITLE
fix: move snapshot generation timeout from bash script to ruby script

### DIFF
--- a/daily_snapshot_terraform/modules/daily_snapshot/prep_sources.sh
+++ b/daily_snapshot_terraform/modules/daily_snapshot/prep_sources.sh
@@ -3,9 +3,9 @@
 # Copy local source files in a folder together with ruby_common and create a zip archive.
 
 cd "$1" || exit
-cp --archive ../../../scripts/ruby_common service/
+cp --archive ../../../scripts/ruby_common service/ || exit
 
 rm -f sources.tar
-(cd service && tar cf ../sources.tar --sort=name --mtime='UTC 2019-01-01' ./* > /dev/null 2>&1)
+(cd service && tar cf ../sources.tar --sort=name --mtime='UTC 2019-01-01' ./* > /dev/null 2>&1) || exit
 rm -fr service/ruby_common
 echo "{ \"path\": \"$1/sources.tar\" }"

--- a/daily_snapshot_terraform/modules/daily_snapshot/service/daily_snapshot.rb
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/daily_snapshot.rb
@@ -34,7 +34,7 @@ unless all_snapshots.empty?
   latest = all_snapshots.first
 
   # Sync and export snapshot
-  snapshot_uploaded = system("bash upload_snapshot.sh #{CHAIN_NAME} #{latest.url} > #{LOG_EXPORT} 2>&1")
+  snapshot_uploaded = system("bash -c 'timeout 24m ./upload_snapshot.sh #{CHAIN_NAME} #{latest.url}' > #{LOG_EXPORT} 2>&1")
 
   # Update our list of snapshots
   all_snapshots = list_snapshots(CHAIN_NAME, BUCKET, ENDPOINT)

--- a/daily_snapshot_terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -2,7 +2,6 @@
 
 # If Forest hasn't synced to the network after 8 hours, something has gone wrong.
 SYNC_TIMEOUT=8h
-DOCKER_TIMEOUT=24h
 
 if [[ $# != 2 ]]; then
   echo "Usage: bash $0 CHAIN_NAME SNAPSHOT_PATH"
@@ -33,8 +32,11 @@ forest-cli --chain $CHAIN_NAME snapshot export -o forest_db/ || { echo "failed t
 HEREDOC
 )
 
+# Stop any lingering docker containers
+docker stop forest-snapshot-upload-node-"$CHAIN_NAME"
+
 # Run forest and generate a snapshot in forest_db/
-timeout $DOCKER_TIMEOUT docker run \
+docker run \
   --name forest-snapshot-upload-node-"$CHAIN_NAME" \
   --rm \
   -v "$BASE_FOLDER/forest_db:/home/forest/forest_db":z \


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- The timeout for the docker command wasn't reliable.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->