### PR TITLE
chore: use the `latest` tag instead of `edge` when generating snapshots

### DIFF
--- a/daily_snapshot_terraform/main.tf
+++ b/daily_snapshot_terraform/main.tf
@@ -31,6 +31,7 @@ module "daily_snapshot" {
   slack_channel     = "#forest-notifications" # slack channel for notifications
   snapshot_bucket   = "forest-snapshots"
   snapshot_endpoint = "fra1.digitaloceanspaces.com"
+  forest_tag        = "latest"
 
   # Variable passthrough:
   slack_token           = var.slack_token

--- a/daily_snapshot_terraform/modules/daily_snapshot/variable.tf
+++ b/daily_snapshot_terraform/modules/daily_snapshot/variable.tf
@@ -45,6 +45,12 @@ variable "snapshot_endpoint" {
   default     = "https://fra1.digitaloceanspaces.com/"
 }
 
+variable "forest_tag" {
+  description = "Image tag for the Forest container"
+  type        = string
+  default     = "latest"
+}
+
 variable "image" {
   description = "The ID of the AMI to use for the Droplet"
   type        = string


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Use the latest release version of Forest instead of the bleeding edge.
- Refactor terraform script to include parameters when deciding whether to redeploy a service.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->