### PR TITLE
use compose subcommand instead of deprecated docker-compose

### DIFF
--- a/sync_check_terraform/modules/sync_check/service/init.sh
+++ b/sync_check_terraform/modules/sync_check/service/init.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 
 ## Install dependencies
 dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo && \
-dnf install -y dnf-plugins-core docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-compose ruby ruby-devel gcc make && \
+dnf install -y dnf-plugins-core docker-ce docker-ce-cli containerd.io docker-buildx-plugin ruby ruby-devel gcc make && \
 dnf clean all
 gem install slack-ruby-client sys-filesystem
 

--- a/sync_check_terraform/modules/sync_check/service/sync_check_process.rb
+++ b/sync_check_terraform/modules/sync_check/service/sync_check_process.rb
@@ -57,23 +57,23 @@ class SyncCheck
     Dir.glob("#{FOREST_DATA}/snapshots/#{network}/*.car")[0] or raise "Can't find snapshot in #{dir}"
   end
 
-  # Starts docker-compose services.
+  # Starts docker compose services.
   def start_services
     @logger.info 'Starting services'
-    `docker-compose up --build --force-recreate --detach`
+    `docker compose up --build --force-recreate --detach`
     raise 'Failed to start services' unless $CHILD_STATUS.success?
   end
 
-  # Stops docker-compose services
+  # Stops docker compose services
   def stop_services
     @logger.info 'Stopping services'
-    `docker-compose down`
+    `docker compose down`
     raise 'Failed to stop services' unless $CHILD_STATUS.success?
   end
 
-  # Checks if the docker-compose services are up
+  # Checks if the docker compose services are up
   def services_up?
-    output = `docker-compose ps --services --filter "status=running"`
+    output = `docker compose ps --services --filter "status=running"`
     $CHILD_STATUS.success? && !output.strip.empty?
   end
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- use `docker compose` instead of `docker-compose` which is no longer **the way**.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest-iac/issues/124


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->