### PR TITLE
relax pruning rules plus add rspec tests

### DIFF
--- a/.github/workflows/tests-daily-snapshot.yml
+++ b/.github/workflows/tests-daily-snapshot.yml
@@ -1,0 +1,27 @@
+name: Snapshot service
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths: 
+      - daily_snapshot_terraform/**
+  push:
+    branches:
+      - main
+    paths:
+      - daily_snapshot_terraform/**
+jobs:
+  rspec:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+      - name: run rspec tests
+        working-directory: daily_snapshot_terraform/modules/daily_snapshot/service
+        run: |
+          gem install --no-document rspec activesupport
+          rspec tests

--- a/daily_snapshot_terraform/modules/daily_snapshot/service/snapshots_prune.rb
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/snapshots_prune.rb
@@ -31,30 +31,21 @@ end
 # Represents Weeks Bucket. The key is "WWYY" (week starts on Monday).
 class WeeksBucket < SnapshotBucket
   def add?(entry)
-    super entry.date.strftime('%m%y')
-  end
-end
-
-# Represents Months Bucket. The key is "MMYY"
-class MonthsBucket < SnapshotBucket
-  def add?(entry)
-    super entry.date.strftime('%m%y')
+    super entry.date.strftime('%W%y')
   end
 end
 
 # Prunes snapshots directory with the following retention policy:
-# * keep at most 1 snapshot per day
+# * keep at most 2 snapshots per day
 # * keep all snapshots generated in the last 7 days,
-# * keep one snapshot per week for the last 4 weeks,
-# * keep one snapshot per month after 4 weeks.
+# * keep one snapshot per week afterwards.
 #
 # Returns pruned snapshots' filenames.
 def prune_snapshots(snapshots)
   day_unique_bucket = DayBucket.new
   day_bucket = DayBucket.new 7
-  weeks_bucket = WeeksBucket.new 4
-  months_bucket = MonthsBucket.new
-  buckets = [day_bucket, weeks_bucket, months_bucket]
+  weeks_bucket = WeeksBucket.new
+  buckets = [day_bucket, weeks_bucket]
 
   # iterate over each entry and try to add it to the buckets, newest first.
   snapshots

--- a/daily_snapshot_terraform/modules/daily_snapshot/service/tests/snapshots_prune_spec.rb
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/tests/snapshots_prune_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require_relative '../snapshots_prune'
+require 'rspec'
+
+describe 'prune_snapshots' do
+  describe 'when there are no snapshots' do
+    it 'returns an empty array' do
+      expect(prune_snapshots([])).to eq([])
+    end
+  end
+
+  describe 'when there is one snapshot' do
+    let(:snapshot) { double(delete: nil, date: '2023-06-27') }
+    it 'it is not deleted' do
+      expect(prune_snapshots([snapshot])).to eq([])
+      expect(snapshot).not_to have_received(:delete)
+    end
+  end
+
+  describe 'when are multiple snapshots for a single day' do
+    # Buffer of two recent snapshots
+    let(:snapshot1) { double(delete: nil, date: '2023-06-27') }
+    # Last snapshot of the day
+    let(:snapshot2) { double(delete: nil, date: '2023-06-27') }
+    # Snapshot to be deleted
+    let(:snapshot3) { double(delete: nil, date: '2023-06-27') }
+
+    it 'deletes all but the first two (assumes snapshots are provided in descending height order)' do
+      pruned_snapshots = prune_snapshots([snapshot1, snapshot2, snapshot3])
+
+      expect(pruned_snapshots).to eq([snapshot3])
+      expect(snapshot1).not_to have_received(:delete)
+      expect(snapshot2).not_to have_received(:delete)
+      expect(snapshot3).to have_received(:delete)
+    end
+  end
+
+  describe 'when there are multiple snapshots for the past week' do
+    # snapshot from Tuesday
+    let(:snapshot1) { double(delete: nil, date: '2023-06-27') }
+    # snapshot from Monday
+    let(:snapshot2) { double(delete: nil, date: '2023-06-26') }
+    # snapshot from Sunday
+    let(:snapshot3) { double(delete: nil, date: '2023-06-25') }
+    # snapshot from last Tuesday
+    let(:snapshot4) { double(delete: nil, date: '2023-06-20') }
+
+    it 'does not delete anything' do
+      pruned_snapshots = prune_snapshots([snapshot1, snapshot2, snapshot3, snapshot4])
+
+      expect(pruned_snapshots).to eq([])
+      [snapshot1, snapshot2, snapshot3].each do |snapshot|
+        expect(snapshot).not_to have_received(:delete)
+      end
+    end
+  end
+
+  describe 'when there are multiple snapshot over more one year' do
+    current_date = Date.parse('2023-06-27')
+    days_in_test = 365
+
+    let :snapshots do
+      (1..days_in_test).map do |i|
+        snapshot_date = current_date - i
+        double(date: snapshot_date, delete: nil)
+      end
+    end
+
+    it 'deletes all but the first one of each week' do
+      snapshots_count = snapshots.length
+      pruned_snapshots = prune_snapshots(snapshots)
+
+      weeks_in_test = days_in_test / 7
+      # Should keep 1 buffer + 7 snapshots in in the first week + 1 snapshot per week afterwards
+      expected_snapshots_keep_count = 1 + 7 + weeks_in_test
+      expect(pruned_snapshots.length).to eq(snapshots_count - expected_snapshots_keep_count)
+
+      snapshots.take(9).each do |snapshot|
+        expect(snapshot).not_to have_received(:delete)
+      end
+
+      # First 9 snapshots should not be deleted
+      # afterwards, only Sunday snapshots should be kept
+      # Year boundary will be kept as well.
+      snapshots.each_with_index do |snapshot, i|
+        if i < 9 || snapshot.date.sunday? || snapshot.date == Date.parse('2022-12-31')
+          expect(snapshot).not_to have_received(:delete)
+        else
+          expect(snapshot).to have_received(:delete)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
1. relaxed pruning rules for the daily snapshot
2. added rspec tests 


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest-iac/issues/105


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->