### PR TITLE
feat: Cleanly destroy services with volumes

### DIFF
--- a/daily_snapshot_terraform/modules/daily_snapshot/main.tf
+++ b/daily_snapshot_terraform/modules/daily_snapshot/main.tf
@@ -94,6 +94,7 @@ resource "digitalocean_droplet" "forest" {
   tags       = ["iac"]
   ssh_keys   = data.digitalocean_ssh_keys.keys.ssh_keys[*].fingerprint
   monitoring = true
+  volume_ids = [digitalocean_volume.forest_storage.id]
 
   graceful_shutdown = false
 
@@ -114,10 +115,6 @@ resource "digitalocean_droplet" "forest" {
   }
 }
 
-resource "digitalocean_volume_attachment" "attach_forest_storage" {
-  droplet_id = digitalocean_droplet.forest.id
-  volume_id  = digitalocean_volume.forest_storage.id
-}
 
 data "digitalocean_project" "forest_project" {
   name = var.project


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Improved the order of creation and destruction on the droplet and volume
```
module.daily_snapshot.digitalocean_droplet.forest: Destroying... [id=364629904]
module.daily_snapshot.digitalocean_droplet.forest: Still destroying... [id=364629904, 10s elapsed]
module.daily_snapshot.digitalocean_droplet.forest: Still destroying... [id=364629904, 20s elapsed]
module.daily_snapshot.digitalocean_droplet.forest: Still destroying... [id=364629904, 30s elapsed]
module.daily_snapshot.digitalocean_droplet.forest: Destruction complete after 32s
module.daily_snapshot.digitalocean_volume.forest_storage: Destroying... [id=df265c8a-1fbe-11ee-96cf-0a58ac14d28d]
module.daily_snapshot.digitalocean_volume.forest_storage: Destruction complete after 0s
```



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #136


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->