### PR TITLE
fix: do not assign everyone to review every pr

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# they will be requested for review when someone opens a pull request.
-*       @elmattic @lemmih @LesnyRumcajs @jdjaustin @hanabi1224 @creativcoder @sudo-shashank @aatifsyed @ruseinov @samuelarogbonlo


### PR DESCRIPTION
**Summary of changes**

We've got a new review assignment system - two per PR, which is out-of-repo.