### PR TITLE
fix: discard lotus chainstore splitstore

### DIFF
--- a/terraform/modules/filecoin_node/lotus.sh
+++ b/terraform/modules/filecoin_node/lotus.sh
@@ -26,10 +26,6 @@ if [ -f "/root/.ssh/authorized_keys" ]; then
   chmod 0600 "/home/${NEW_USER}/.ssh/authorized_keys"
 fi
 
-#install NTP to synchronize the time differences
-timedatectl set-ntp no
-apt install -y ntp
-
 # Restrict SSH access to the new user only. preventing root user from accessing the system via SSH.
 echo "AllowUsers ${NEW_USER}" >> /etc/ssh/sshd_config
 systemctl restart sshd
@@ -76,7 +72,7 @@ sudo --user="${NEW_USER}" -- \
   filecoin/lotus-all-in-one:"$IMAGETAG" lotus daemon \
   --import-snapshot https://snapshots."${CHAIN}".filops.net/minimal/latest.zst
 
-# It monitors running Docker containers and watches for changes to the images that those containers were originally started from. 
+# It monitors running Docker containers and watches for changes to the images that those containers were originally started from.
 # If Watchtower detects that an image has changed, it will automatically restart the container using the new image.
 # Run the Watchtower Docker container as created user.
 sudo --user="${NEW_USER}" -- \

--- a/terraform/modules/filecoin_node/lotus.sh
+++ b/terraform/modules/filecoin_node/lotus.sh
@@ -65,6 +65,7 @@ sudo --user="${NEW_USER}" -- \
   --detach \
   --network=lotus \
   --name=lotus-"${CHAIN}" \
+  --env LOTUS_CHAINSTORE_SPLITSTORE_COLDSTORETYPE="discard" \
   --volume=parameters:/var/tmp/filecoin-proof-parameters \
   --volume=/home/"${NEW_USER}"/lotus_data:/var/lib/lotus \
   --publish=1234:1234 \

--- a/terraform/modules/filecoin_node/user-data.sh
+++ b/terraform/modules/filecoin_node/user-data.sh
@@ -26,10 +26,6 @@ if [ -f "/root/.ssh/authorized_keys" ]; then
   chmod 0600 "/home/${NEW_USER}/.ssh/authorized_keys"
 fi
 
-#install NTP to synchronize the time differences
-timedatectl set-ntp no
-apt install -y ntp
-
 # Restrict SSH access to the new user only. preventing root user from accessing the system via SSH.
 echo "AllowUsers ${NEW_USER}" >> /etc/ssh/sshd_config
 
@@ -76,9 +72,9 @@ sudo --user="${NEW_USER}" -- \
   --config=/home/"${NEW_USER}"/data/config.toml \
   --encrypt-keystore false \
   --auto-download-snapshot \
-  --chain="${CHAIN}" 
+  --chain="${CHAIN}"
 
-# It monitors running Docker containers and watches for changes to the images that those containers were originally started from. 
+# It monitors running Docker containers and watches for changes to the images that those containers were originally started from.
 # If Watchtower detects that an image has changed, it will automatically restart the container using the new image.
 # Run the Watchtower Docker container as created user.
 sudo --user="${NEW_USER}" -- \
@@ -118,7 +114,7 @@ retries: 3
 log_level: info
 EOF
 
-# Runs Prometheus OpenMetrics integration Docker container 
+# Runs Prometheus OpenMetrics integration Docker container
 # for Collection of Forest's Prometheus metrics.
 sudo --user="${NEW_USER}" -- \
   docker run \


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Changed  lotus `LOTUS_CHAINSTORE_SPLITSTORE_COLDSTORETYPE` to `discard`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->