### PR TITLE
downgrade fedora for sync check

### DIFF
--- a/sync_check_terraform/modules/sync_check/service/Dockerfile-tester
+++ b/sync_check_terraform/modules/sync_check/service/Dockerfile-tester
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:36
 
 RUN dnf -y install dnf-plugins-core && \
     dnf config-manager \

--- a/sync_check_terraform/modules/sync_check/variable.tf
+++ b/sync_check_terraform/modules/sync_check/variable.tf
@@ -26,7 +26,7 @@ variable "slack_token" {
 variable "image" {
   description = "The ID of the AMI to use for the Droplet"
   type        = string
-  default     = "fedora-38-x64"
+  default     = "fedora-36-x64"
 }
 
 variable "region" {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- let's downgrade Fedora back to 36 for now. The root issue of `forest-tester` missing `calibnet` network has been resolved in https://github.com/docker/compose/pull/10778, but it's difficult to say when it will land in the DNF registry.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->