### PR TITLE
feat: docker-compose.yml for actor bundle ipfs file host

### DIFF
--- a/ipfs/docker-compose.yml
+++ b/ipfs/docker-compose.yml
@@ -1,0 +1,23 @@
+# Docker compose file to run a ipfs node that serves the files defined in init.sh
+# Run command: `docker compose up --build --force-recreate --detach`
+# Check stats: `docker exec forest-ipfs ipfs stats bw`
+
+version: "3.7"
+
+services:
+  forest_ipfs:
+    image: ipfs/kubo
+    container_name: forest-ipfs
+    ports:
+      - "4001:4001"
+      - "4001:4001/udp"
+      - "8080:8080"
+      - "8081:8081"
+    volumes:
+      - type: bind
+        source: init.sh
+        target: /container-init.d/forest-init.sh
+    command:
+    restart: unless-stopped
+    labels:
+      com.centurylinklabs.watchtower.enable: true

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+## Enable strict error handling, command tracing
+set -eux
+
+fetch_add() {
+    # wget is available in ipfs/kubo image as part of BusyBox
+    wget "$1" --no-verbose -O /tmp/.tmpfile
+    ipfs add /tmp/.tmpfile
+    rm /tmp/.tmpfile
+}
+
+## IPFS CID can be found in docker log, `docker logs forest-ipfs`
+
+fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v9.0.3/builtin-actors-calibrationnet.car
+fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v10.0.0-rc.1/builtin-actors-calibrationnet.car
+fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v11.0.0-rc2/builtin-actors-calibrationnet.car
+fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v9.0.3/builtin-actors-mainnet.car
+fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v10.0.0/builtin-actors-mainnet.car
+fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v11.0.0/builtin-actors-mainnet.car

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -15,6 +15,10 @@ fetch_add() {
 fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v9.0.3/builtin-actors-calibrationnet.car
 fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v10.0.0-rc.1/builtin-actors-calibrationnet.car
 fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v11.0.0-rc2/builtin-actors-calibrationnet.car
+
+fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v10.0.0/builtin-actors-devnet.car
+fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v11.0.0/builtin-actors-devnet.car
+
 fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v9.0.3/builtin-actors-mainnet.car
 fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v10.0.0/builtin-actors-mainnet.car
 fetch_add https://github.com/filecoin-project/builtin-actors/releases/download/v11.0.0/builtin-actors-mainnet.car


### PR DESCRIPTION
**Summary of changes**

Part of https://github.com/ChainSafe/forest/issues/2765

Changes introduced in this pull request:
- docker-compose for actor bundle ipfs file host

The container is currently running on a DO droplet with `docker compose up --build --force-recreate --detach`, providing data to the IPFS public HTTP gateway.

Questions:
1. Do we want to use the private HTTP gateway? 
2. If the answer to 1 is yes, do we want to terraform this?
3. If the answer to 1 is yes, do we want to add SSL to the gateway (via ngnix and certbot)?

Example mapping: 
https://github.com/filecoin-project/builtin-actors/releases/download/v9.0.3/builtin-actors-calibrationnet.car at  https://ipfs.io/ipfs/QmVy2u2Gwa21hmbQvv7LGkGNTn2GmVxv1gwTfBeuWSBp1H

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->