### PR TITLE
use standard fedora docker

### DIFF
--- a/sync_check_terraform/modules/sync_check/service/Dockerfile-tester
+++ b/sync_check_terraform/modules/sync_check/service/Dockerfile-tester
@@ -1,15 +1,7 @@
 FROM fedora:38
 
-RUN dnf -y install dnf-plugins-core && \
-    dnf config-manager \
-        --add-repo \
-        https://download.docker.com/linux/fedora/docker-ce.repo && dnf clean all
-
 RUN dnf install -y \
-    docker-ce \
-    docker-ce-cli \
-    containerd.io \
-    docker-buildx-plugin \
+    docker \
     ruby \
     ruby-devel \
     make \

--- a/sync_check_terraform/modules/sync_check/service/docker-compose.yml
+++ b/sync_check_terraform/modules/sync_check/service/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       context: .
       dockerfile: Dockerfile-tester
     container_name: forest-tester
+    privileged: true
     networks:
       - mainnet
       - calibnet

--- a/sync_check_terraform/modules/sync_check/service/init.sh
+++ b/sync_check_terraform/modules/sync_check/service/init.sh
@@ -4,9 +4,8 @@
 set -euxo pipefail
 
 ## Install dependencies
-dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo && \
-dnf install -y dnf-plugins-core docker-ce docker-ce-cli containerd.io docker-buildx-plugin ruby ruby-devel gcc make && \
-dnf clean all
+dnf install -y dnf-plugins-core docker docker-compose ruby ruby-devel gcc make && \
+  dnf clean all
 gem install slack-ruby-client sys-filesystem
 
 nohup /bin/bash ./run_service.sh > run_service_log.txt &

--- a/sync_check_terraform/modules/sync_check/service/run_service.sh
+++ b/sync_check_terraform/modules/sync_check/service/run_service.sh
@@ -29,6 +29,7 @@ docker wait watchtower 2> /dev/null || true
 docker run \
     --detach \
     --restart unless-stopped \
+    --privileged \
     -v /var/run/docker.sock:/var/run/docker.sock \
     --name watchtower \
     containrrr/watchtower \

--- a/sync_check_terraform/modules/sync_check/service/sync_check_process.rb
+++ b/sync_check_terraform/modules/sync_check/service/sync_check_process.rb
@@ -55,20 +55,20 @@ class SyncCheck
   # Starts docker compose services.
   def start_services
     @logger.info 'Starting services'
-    `docker compose up --build --force-recreate --detach`
+    `docker-compose up --build --force-recreate --detach`
     raise 'Failed to start services' unless $CHILD_STATUS.success?
   end
 
   # Stops docker compose services
   def stop_services
     @logger.info 'Stopping services'
-    `docker compose down`
+    `docker-compose down`
     raise 'Failed to stop services' unless $CHILD_STATUS.success?
   end
 
   # Checks if the docker compose services are up
   def services_up?
-    output = `docker compose ps --services --filter "status=running"`
+    output = `docker-compose ps --services --filter "status=running"`
     $CHILD_STATUS.success? && !output.strip.empty?
   end
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- this makes the service run on a recent Fedora image but with an older Docker. See https://github.com/docker/compose/issues/10777 that was causing `forest-tester` to fail from time to time. In the end, it should get resolved, but using Fedora packages is safer than the bleeding-edge Docker packages.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->