### PR TITLE
fix: disable GCing when exporting a new snapshot

### DIFF
--- a/daily_snapshot_terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -61,7 +61,7 @@ write_metrics &
 
 forest-cli --config config.toml --chain "$CHAIN_NAME" db clean --force
 forest --config config.toml --chain "$CHAIN_NAME" --import-snapshot "$NEWEST_SNAPSHOT" --halt-after-import
-forest --config config.toml --chain "$CHAIN_NAME" --detach
+forest --config config.toml --chain "$CHAIN_NAME" --no-gc --detach
 timeout "$SYNC_TIMEOUT" forest-cli --chain "$CHAIN_NAME" sync wait
 forest-cli --chain "$CHAIN_NAME" snapshot export -o forest_db/
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Locally, I get disconnects and `ChainExchange` failures when the GC runs. Maybe the GC blocks DB access which causes failed p2p responses which leads to disconnecting peers.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->