### PR TITLE
allow only one workflow to run concurrently on branch

### DIFF
--- a/.github/workflows/deploy-forest-calibnet.yml
+++ b/.github/workflows/deploy-forest-calibnet.yml
@@ -1,4 +1,5 @@
 name: Forest Calibnet
+concurrency: ci-${{ github.ref }}
 
 on:
   pull_request:

--- a/.github/workflows/deploy-forest-mainnet.yml
+++ b/.github/workflows/deploy-forest-mainnet.yml
@@ -1,4 +1,5 @@
 name: Forest Mainnet
+concurrency: ci-${{ github.ref }}
 
 on:
   pull_request:

--- a/.github/workflows/deploy-lotus-mainnet.yml
+++ b/.github/workflows/deploy-lotus-mainnet.yml
@@ -1,4 +1,5 @@
 name: Lotus Mainnet
+concurrency: ci-${{ github.ref }}
 
 on:
   pull_request:

--- a/.github/workflows/deploy-new-relic.yml
+++ b/.github/workflows/deploy-new-relic.yml
@@ -1,4 +1,5 @@
 name: New-Relic
+concurrency: ci-${{ github.ref }}
 
 on:
   pull_request:

--- a/.github/workflows/deploy-sync-check.yml
+++ b/.github/workflows/deploy-sync-check.yml
@@ -1,5 +1,6 @@
 ---
 name: Sync Check Service
+concurrency: ci-${{ github.ref }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
 name: Snapshot Service
+concurrency: ci-${{ github.ref }}
 
 on:
   pull_request:

--- a/.github/workflows/deploy_snapshot_function.yml
+++ b/.github/workflows/deploy_snapshot_function.yml
@@ -1,4 +1,5 @@
 name: Forest Calibnet 
+concurrency: ci-${{ github.ref }}
 
 on:
   pull_request:


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Without the lock, we get into data race when one PR that triggers a TF apply is followed by another one. See example:

This rightfully rebuilt `sync-check` given a different dependencies list.
https://github.com/ChainSafe/forest-iac/actions/runs/5627335480/job/15249710896
A minute after this was run, which also detected state diff, and so it triggered a TF at the same time.
https://github.com/ChainSafe/forest-iac/actions/runs/5627341002/job/15249722968

We ended up with two `sync-check` droplets doing the same and having precisely the same state.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->