### PR TITLE
feat: allow snapshot files ending in .forest.car.zst

### DIFF
--- a/daily_snapshot_terraform/modules/daily_snapshot/service/list_snapshots.rb
+++ b/daily_snapshot_terraform/modules/daily_snapshot/service/list_snapshots.rb
@@ -49,7 +49,7 @@ end
 # List the snapshots available in the S3 space hosted by Forest
 def list_snapshots(chain_name = 'calibnet', bucket = 'forest-snapshots', endpoint = 'fra1.digitaloceanspaces.com')
   ls_format = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}\s*\d*\s*s3:\/\/#{bucket}\/#{chain_name}\/(.+)/
-  snapshot_format = /^([^_]+?)_snapshot_(?<network>[^_]+?)_(?<date>\d{4}-\d{2}-\d{2})_height_(?<height>\d+)\.car.zst$/
+  snapshot_format = /^([^_]+?)_snapshot_(?<network>[^_]+?)_(?<date>\d{4}-\d{2}-\d{2})_height_(?<height>\d+)\.(\.forest)?car.zst$/
 
   output = `s3cmd ls s3://#{bucket}/#{chain_name}/`
 

--- a/do_function/snapshot_function/packages/latest-snapshot/link/link.js
+++ b/do_function/snapshot_function/packages/latest-snapshot/link/link.js
@@ -26,7 +26,7 @@ export async function main(args) {
   let s3_listing = parser.parse(body);
 
   const re =
-    /([^_]+?)_snapshot_([^_]+?)_(\d{4}-\d{2}-\d{2})_height_(\d+).car(.zst)?$/;
+    /([^_]+?)_snapshot_([^_]+?)_(\d{4}-\d{2}-\d{2})_height_(\d+)(\.forest)?\.car(\.zst)?$/;
 
   var snapshots = [];
 
@@ -40,7 +40,7 @@ export async function main(args) {
         network: myArray[2],
         date: myArray[3],
         epoch: parseInt(myArray[4]),
-        compressed: myArray[5] === ".zst",
+        compressed: myArray[6] === ".zst",
       };
       if (snapshot.network === network && snapshot.compressed === compressed) {
         snapshots.push(snapshot);


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- new snapshot files will have the extension `.forest.car.zst`. This PR updates our services to correctly parse such files.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->