### PR TITLE
fix: enable Chainstore.Splitstore for lotus

### DIFF
--- a/terraform/modules/filecoin_node/lotus.sh
+++ b/terraform/modules/filecoin_node/lotus.sh
@@ -53,9 +53,9 @@ chown --recursive "${NEW_USER}":"${NEW_USER}" "/home/${NEW_USER}/lotus_data"
 
 cat << EOF > "/home/${NEW_USER}/lotus_data/config.toml"
 [Chainstore]
-  EnableSplitstore = true
-  [Chainstore.Splitstore]
-    ColdStoreType = "discard"
+EnableSplitstore = true
+[Chainstore.Splitstore]
+ColdStoreType = "discard"
 EOF
 
 IMAGETAG="stable"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Enable Chainstore Splitstore for lotus



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->