### PR TITLE
fix snapshots data race

### DIFF
--- a/terraform/modules/daily_snapshot/service/daily_snapshot.rb
+++ b/terraform/modules/daily_snapshot/service/daily_snapshot.rb
@@ -24,8 +24,6 @@ raise 'No chain name supplied. Please provide chain identifier, e.g. calibnet or
 DATE = Time.new.strftime '%FT%H:%M:%S'
 LOG_EXPORT = "#{CHAIN_NAME}_#{DATE}_export.txt"
 
-SNAPSHOTS_DIR = File.join(BASE_FOLDER, 's3', CHAIN_NAME)
-
 client = SlackClient.new CHANNEL, SLACK_TOKEN
 
 # Find the snapshot with the most recent modification date

--- a/terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -84,19 +84,21 @@ HEREDOC
 # Stop any lingering docker containers
 docker stop forest-snapshot-upload-node-"$CHAIN_NAME"
 
+CHAIN_DB_DIR="$BASE_FOLDER/forest_db/$CHAIN_NAME"
+
 # Run forest and generate a snapshot in forest_db/
 docker run \
   --name forest-snapshot-upload-node-"$CHAIN_NAME" \
   --rm \
   --user root \
-  -v "$BASE_FOLDER/forest_db:/home/forest/forest_db":z \
+  -v "$CHAIN_DB_DIR:/home/forest/forest_db":z \
   --entrypoint /bin/bash \
   ghcr.io/chainsafe/forest:"${FOREST_TAG}" \
   -c "$COMMANDS" || exit 1
 
 # Upload snapshot to s3
-s3cmd --acl-public put "$BASE_FOLDER/forest_db/forest_snapshot_$CHAIN_NAME"* s3://"$SNAPSHOT_BUCKET"/"$CHAIN_NAME"/ || exit 1
+s3cmd --acl-public put "$CHAIN_DB_DIR/forest_snapshot_$CHAIN_NAME"* s3://"$SNAPSHOT_BUCKET"/"$CHAIN_NAME"/ || exit 1
 
 # Delete snapshot files
-rm "$BASE_FOLDER/forest_db/forest_snapshot_$CHAIN_NAME"*
+rm "$CHAIN_DB_DIR/forest_snapshot_$CHAIN_NAME"*
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

- there was a data race in the snapshots directory; mainnet snapshot service was using the same path as the calibnet snapshot, which mounted under the same mount point - this resulted in e.g., validating mainnet snapshots by calibnet snapshot service. It might be the culprit for https://github.com/ChainSafe/forest/issues/3309




**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->