### PR TITLE
fix container conflict error

### DIFF
--- a/terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -82,13 +82,15 @@ HEREDOC
 )
 
 # Stop any lingering docker containers
-docker stop forest-snapshot-upload-node-"$CHAIN_NAME"
+CONTAINER_NAME="forest-snapshot-upload-node-$CHAIN_NAME"
+docker stop "$CONTAINER_NAME" || true
+docker rm --force "$CONTAINER_NAME"
 
 CHAIN_DB_DIR="$BASE_FOLDER/forest_db/$CHAIN_NAME"
 
 # Run forest and generate a snapshot in forest_db/
 docker run \
-  --name forest-snapshot-upload-node-"$CHAIN_NAME" \
+  --name "$CONTAINER_NAME" \
   --rm \
   --user root \
   -v "$CHAIN_DB_DIR:/home/forest/forest_db":z \


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- it should fix
```
latest: Pulling from chainsafe/forest
Digest: sha256:37f9b31732ed0c90ae0fdd90478e3375c98907182642371080ace9768f06265b
Status: Image is up to date for ghcr.io/chainsafe/forest:latest
ghcr.io/chainsafe/forest:latest
forest-snapshot-upload-node-calibnet
docker: Error response from daemon: Conflict. The container name "/forest-snapshot-upload-node-calibnet" is already in use by container "ecbe71c34b8113f5f54abad73d58cc17934f63527784801a6792fa256ac07f89". You have to remove (or rename) that container to be able to reuse that name.
See 'docker run --help'.
```



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->