### PR TITLE
fix: limit diff depth and use canonical names for diff snapshots

### DIFF
--- a/archival-snapshots-generate/src/main.rs
+++ b/archival-snapshots-generate/src/main.rs
@@ -155,7 +155,7 @@ fn generate_diff_snapshot(
     let diff_snapshot_name = format!(
         "forest_diff_{}_{}_height_{}+{}.forest.car.zst",
         network,
-        epoch_to_date(diff + diff_snapshot_depth),
+        epoch_to_date(network, diff + diff_snapshot_depth)?,
         diff,
         diff_snapshot_depth
     );
@@ -189,14 +189,18 @@ fn generate_diff_snapshot(
     Ok(())
 }
 
-fn epoch_to_date(epoch: ChainEpoch) -> String {
-    let genesis_timestamp = 1667326380;
+fn epoch_to_date(network: &str, epoch: ChainEpoch) -> anyhow::Result<String> {
+    let genesis_timestamp = match network {
+        "mainnet" => 1598306400,
+        "calibnet" => 1667326380,
+        _ => bail!("unsupported network"),
+    };
 
-    NaiveDateTime::from_timestamp_opt(
+    Ok(NaiveDateTime::from_timestamp_opt(
         (genesis_timestamp + epoch * EPOCH_DURATION_SECONDS) as i64,
         0,
     )
     .unwrap_or_default()
     .format("%Y-%m-%d")
-    .to_string()
+    .to_string())
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Diff snapshots may not omit data from _before_ the previous lite snapshot. Fixing this means using the `--diff-depth` flag.
- Include dates in the filenames of diff snapshots.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->