### PR TITLE
clean snapshots before snapshot upload

### DIFF
--- a/terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -88,6 +88,10 @@ docker rm --force "$CONTAINER_NAME"
 
 CHAIN_DB_DIR="$BASE_FOLDER/forest_db/$CHAIN_NAME"
 
+# Delete any existing snapshot files. It may be that the previous run failed
+# before deleting those.
+rm "$CHAIN_DB_DIR/forest_snapshot_$CHAIN_NAME"*
+
 # Run forest and generate a snapshot in forest_db/
 docker run \
   --name "$CONTAINER_NAME" \


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- this fixes multiple snapshots being uploaded because of errors in previous runs
```
upload: '/root/forest_db/calibnet/forest_snapshot_calibnet_2023-08-21_height_842169.forest.car.sha256sum' -> 's3://forest-snapshots/calibnet/forest_snapshot_calibnet_2023-08-21_height_842169.forest.car.sha256sum' (130 bytes in 0.0 seconds, 4.80 KB/s) [1 of 6]
Public URL of the object is: http://forest-snapshots.fra1.digitaloceanspaces.com/calibnet/forest_snapshot_calibnet_2023-08-21_height_842169.forest.car.sha256sum
upload: '/root/forest_db/calibnet/forest_snapshot_calibnet_2023-08-21_height_842169.forest.car.zst' -> 's3://forest-snapshots/calibnet/forest_snapshot_calibnet_2023-08-21_height_842169.forest.car.zst' (1551778003 bytes in 15.6 seconds, 95.04 MB/s) [2 of 6]
Public URL of the object is: http://forest-snapshots.fra1.digitaloceanspaces.com/calibnet/forest_snapshot_calibnet_2023-08-21_height_842169.forest.car.zst
upload: '/root/forest_db/calibnet/forest_snapshot_calibnet_2023-08-21_height_842289.forest.car.sha256sum' -> 's3://forest-snapshots/calibnet/forest_snapshot_calibnet_2023-08-21_height_842289.forest.car.sha256sum' (130 bytes in 0.0 seconds, 4.51 KB/s) [3 of 6]
Public URL of the object is: http://forest-snapshots.fra1.digitaloceanspaces.com/calibnet/forest_snapshot_calibnet_2023-08-21_height_842289.forest.car.sha256sum
upload: '/root/forest_db/calibnet/forest_snapshot_calibnet_2023-08-21_height_842289.forest.car.zst' -> 's3://forest-snapshots/calibnet/forest_snapshot_calibnet_2023-08-21_height_842289.forest.car.zst' (1552136457 bytes in 17.6 seconds, 84.28 MB/s) [4 of 6]
Public URL of the object is: http://forest-snapshots.fra1.digitaloceanspaces.com/calibnet/forest_snapshot_calibnet_2023-08-21_height_842289.forest.car.zst
upload: '/root/forest_db/calibnet/forest_snapshot_calibnet_2023-08-21_height_842409.forest.car.sha256sum' -> 's3://forest-snapshots/calibnet/forest_snapshot_calibnet_2023-08-21_height_842409.forest.car.sha256sum' (130 bytes in 0.0 seconds, 10.21 KB/s) [5 of 6]
Public URL of the object is: http://forest-snapshots.fra1.digitaloceanspaces.com/calibnet/forest_snapshot_calibnet_2023-08-21_height_842409.forest.car.sha256sum
upload: '/root/forest_db/calibnet/forest_snapshot_calibnet_2023-08-21_height_842409.forest.car.zst' -> 's3://forest-snapshots/calibnet/forest_snapshot_calibnet_2023-08-21_height_842409.forest.car.zst' (2090179839 bytes in 21.9 seconds, 90.94 MB/s) [6 of 6]
Public URL of the object is: http://forest-snapshots.fra1.digitaloceanspaces.com/calibnet/forest_snapshot_calibnet_2023-08-21_height_842409.forest.car.zst
```

or 


```
+ '[' calibnet = calibnet ']'
+ forest-cli snapshot validate --check-network calibnet forest_db/forest_snapshot_calibnet_2023-08-21_height_842169.forest.car.zst forest_db/forest_snapshot_calibnet_2023-08-21_height_842289.forest.car.zst forest_db/forest_snapshot_calibnet_2023-08-21_height_842409.forest.car.zst
```



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->