### PR TITLE
fix: use the new forest-tool binary

### DIFF
--- a/archival-snapshots-generate/src/main.rs
+++ b/archival-snapshots-generate/src/main.rs
@@ -38,13 +38,16 @@ fn main() -> anyhow::Result<()> {
     if which::which("forest-cli").is_err() {
         bail!("forest-cli is not installed");
     }
+    if which::which("forest-tool").is_err() {
+        bail!("forest-tool is not installed");
+    }
 
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     let args = Args::parse();
 
     info!("Analyzing the provided snapshot file");
-    let epochs = std::process::Command::new("forest-cli")
+    let epochs = std::process::Command::new("forest-tool")
         .args([
             "archive",
             "info",


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- `forest-cli archive info` is now `forest-tool archive info`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->