### PR TITLE
chore: restrutured forest dashboards

### DIFF
--- a/terraform/new-relic/forest.json
+++ b/terraform/new-relic/forest.json
@@ -308,38 +308,44 @@
         {
           "title": "Bad Peers",
           "layout": {
-            "column": 5,
+            "column": 1,
             "row": 1,
-            "width": 4,
+            "width": 6,
             "height": 3
           },
           "linkedEntityGuids": null,
           "visualization": {
-            "id": "viz.billboard"
+            "id": "viz.line"
           },
           "rawConfiguration": {
             "facet": {
               "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
             },
             "nrqlQueries": [
               {
                 "accountIds": [
                   "${account_id}"
                 ],
-                "query": "SELECT latest(bad_peers) FROM Metric WHERE clusterName = '${name}' SINCE 1 day ago UNTIl NOW"
+                "query": "SELECT latest(bad_peers) FROM Metric WHERE clusterName = '${name}' TIMESERIES AUTO "
               }
             ],
             "platformOptions": {
               "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
             }
           }
         },
         {
           "title": "Peer Disconnected P2P Events",
           "layout": {
-            "column": 9,
+            "column": 7,
             "row": 1,
-            "width": 4,
+            "width": 6,
             "height": 3
           },
           "linkedEntityGuids": null,
@@ -447,7 +453,7 @@
           "layout": {
             "column": 1,
             "row": 7,
-            "width": 4,
+            "width": 6,
             "height": 3
           },
           "linkedEntityGuids": null,
@@ -480,9 +486,9 @@
         {
           "title": "Message P2P Events",
           "layout": {
-            "column": 5,
+            "column": 7,
             "row": 7,
-            "width": 8,
+            "width": 6,
             "height": 3
           },
           "linkedEntityGuids": null,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Restrutured forest dashboards
- Change the dashboards. They should are more structured, with several pages, the first one being an executive summary with only the following metrics
   -  Head epoch,
   - Tipsets validated per minute (this should be always ~2),
   - Full peers
   - Process uptime (single number)
   - CPU usage,
   - Memory usage (Process Resident Memory and NOT virtual memory),
  -  Disk usage, total available disk size, and disk usage percentage.




**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #236 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->