### PR TITLE
feat: cf worker for fetching most recent snapshots

### DIFF
--- a/cf/latest-snapshot/.editorconfig
+++ b/cf/latest-snapshot/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+tab_width = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yml]
+indent_style = space

--- a/cf/latest-snapshot/.prettierrc
+++ b/cf/latest-snapshot/.prettierrc
@@ -1,0 +1,19 @@
+{
+	"semi": true,
+	"printWidth": 100,
+	"singleQuote": true,
+	"bracketSpacing": true,
+	"insertPragma": false,
+	"requirePragma": false,
+	"jsxSingleQuote": false,
+	"bracketSameLine": false,
+	"embeddedLanguageFormatting": "auto",
+	"htmlWhitespaceSensitivity": "css",
+	"vueIndentScriptAndStyle": true,
+	"quoteProps": "consistent",
+	"proseWrap": "preserve",
+	"trailingComma": "es5",
+	"arrowParens": "avoid",
+	"useTabs": true,
+	"tabWidth": 2
+}

--- a/cf/latest-snapshot/README.md
+++ b/cf/latest-snapshot/README.md
@@ -1,0 +1,44 @@
+# Template: worker-r2
+
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-r2)
+
+A template for interfacing with an R2 bucket from within a Cloudflare Worker.
+
+Please refer to the [Use R2 from Workers](https://developers.cloudflare.com/r2/data-access/workers-api/workers-api-usage/) documentation when using this template.
+
+## Setup
+
+To create a `my-project` directory using this template, run:
+
+```sh
+$ npx wrangler generate my-project worker-r2
+# or
+$ yarn wrangler generate my-project worker-r2
+# or
+$ pnpm wrangler generate my-project worker-r2
+```
+
+## Getting started
+
+Run the following commands in the console:
+
+```sh
+# Next, make sure you've logged in
+npx wrangler login
+
+# Create your R2 bucket
+npx wrangler r2 bucket create <YOUR_BUCKET_NAME>
+
+# Add config to wrangler.toml as instructed
+
+# Deploy the worker
+npx wrangler deploy
+```
+
+Then test out your new Worker!
+
+## Note about access and privacy
+
+With the default code in this template, every incoming request has the ability to interact with your R2 bucket. This means your bucket is publicly exposed and its contents can be accessed and modified by undesired actors.
+
+You must define authorization logic to determine who can perform what actions to your bucket. To know more about this take a look at the [Bucket access and privacy](https://developers.cloudflare.com/r2/data-access/workers-api/workers-api-usage/#6-bucket-access-and-privacy) section of the **Use R2 from Workers** documentation

--- a/cf/latest-snapshot/README.md
+++ b/cf/latest-snapshot/README.md
@@ -1,44 +1,12 @@
-# Template: worker-r2
+# Snapshot redirect worker
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-r2)
+This worker acts on two endpoints:
 
-A template for interfacing with an R2 bucket from within a Cloudflare Worker.
+- `https://forest-archive.chainsafe.dev/latest/calibnet/`
+- `https://forest-archive.chainsafe.dev/latest/mainnet/`
 
-Please refer to the [Use R2 from Workers](https://developers.cloudflare.com/r2/data-access/workers-api/workers-api-usage/) documentation when using this template.
+These links will download the latest available snapshot for calibnet and mainnet, respectively.
 
-## Setup
+# Local deployment
 
-To create a `my-project` directory using this template, run:
-
-```sh
-$ npx wrangler generate my-project worker-r2
-# or
-$ yarn wrangler generate my-project worker-r2
-# or
-$ pnpm wrangler generate my-project worker-r2
-```
-
-## Getting started
-
-Run the following commands in the console:
-
-```sh
-# Next, make sure you've logged in
-npx wrangler login
-
-# Create your R2 bucket
-npx wrangler r2 bucket create <YOUR_BUCKET_NAME>
-
-# Add config to wrangler.toml as instructed
-
-# Deploy the worker
-npx wrangler deploy
-```
-
-Then test out your new Worker!
-
-## Note about access and privacy
-
-With the default code in this template, every incoming request has the ability to interact with your R2 bucket. This means your bucket is publicly exposed and its contents can be accessed and modified by undesired actors.
-
-You must define authorization logic to determine who can perform what actions to your bucket. To know more about this take a look at the [Bucket access and privacy](https://developers.cloudflare.com/r2/data-access/workers-api/workers-api-usage/#6-bucket-access-and-privacy) section of the **Use R2 from Workers** documentation
+Use `wrangler dev` to deploy a local version of this worker which will use the `forest-archive-dev` bucket rather than the production `forest-archive` bucket. Merging changes to this worker will automatically deploy them.

--- a/cf/latest-snapshot/package.json
+++ b/cf/latest-snapshot/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "template-worker-r2",
+	"version": "0.0.0",
+	"private": true,
+	"scripts": {
+		"deploy": "wrangler deploy src/index.ts",
+		"dev": "wrangler dev src/index.ts --local",
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev src/index.ts --local"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20230904.0",
+		"wrangler": "^3.0.0"
+	}
+}

--- a/cf/latest-snapshot/package.json
+++ b/cf/latest-snapshot/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "template-worker-r2",
+	"name": "forest-latest-snapshot",
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {

--- a/cf/latest-snapshot/src/index.ts
+++ b/cf/latest-snapshot/src/index.ts
@@ -1,0 +1,44 @@
+interface Env {
+	FOREST_ARCHIVE: R2Bucket,
+}
+
+function basename(path: String) {
+	return path.split('/').reverse()[0];
+}
+
+async function get_latest(env: Env, chain: string): Promise<Response> {
+	const listed = await env.FOREST_ARCHIVE.list({ prefix: chain + "/latest/" });
+	let latest = listed.objects.at(-1);
+	if (latest == null) {
+		return new Response(`No latest snapshot found ${chain}`, {
+			status: 404,
+		});
+	} else {
+		// Should we support range queries?
+		const object = await env.FOREST_ARCHIVE.get(latest.key);
+		if (object === null) {
+			return new Response('No latest snapshot found', {
+				status: 404,
+			});
+		}
+		const headers = new Headers();
+		object.writeHttpMetadata(headers);
+		headers.set('etag', object.httpEtag);
+		let encoded_name = encodeURIComponent(basename(object.key));
+		headers.set('content-disposition', `attachment; filename*=UTF-8''${encoded_name}; filename="${encoded_name}"`);
+
+		return new Response(object.body, {
+			headers,
+		});
+	}
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const url = new URL(request.url);
+		const myRe = /\/latest\/(\w*)/;
+		const chain = (url.pathname.match(myRe) || ["undefined"])[1];
+
+		return await get_latest(env, chain);
+	},
+};

--- a/cf/latest-snapshot/src/index.ts
+++ b/cf/latest-snapshot/src/index.ts
@@ -6,6 +6,7 @@ function basename(path: String) {
 	return path.split('/').reverse()[0];
 }
 
+// Directly fetch the data for the latest snapshot of a given chain (eg. calibnet or mainnet)
 async function get_latest(env: Env, chain: string): Promise<Response> {
 	const listed = await env.FOREST_ARCHIVE.list({ prefix: chain + "/latest/" });
 	let latest = listed.objects.at(-1);
@@ -25,6 +26,7 @@ async function get_latest(env: Env, chain: string): Promise<Response> {
 		object.writeHttpMetadata(headers);
 		headers.set('etag', object.httpEtag);
 		let encoded_name = encodeURIComponent(basename(object.key));
+		// Tell browsers and aria2c which filename to use. For 'wget', you have to use `--trust-server-names`.
 		headers.set('content-disposition', `attachment; filename*=UTF-8''${encoded_name}; filename="${encoded_name}"`);
 
 		return new Response(object.body, {
@@ -36,8 +38,7 @@ async function get_latest(env: Env, chain: string): Promise<Response> {
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
 		const url = new URL(request.url);
-		const myRe = /\/latest\/(\w*)/;
-		const chain = (url.pathname.match(myRe) || ["undefined"])[1];
+		const chain = (url.pathname.match(/\/latest\/(\w*)/) || ["undefined"])[1];
 
 		return await get_latest(env, chain);
 	},

--- a/cf/latest-snapshot/tsconfig.json
+++ b/cf/latest-snapshot/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"noEmit": true,
+		"module": "esnext",
+		"target": "esnext",
+		"lib": ["esnext"],
+		"strict": true,
+		"moduleResolution": "node",
+		"types": ["@cloudflare/workers-types", "@types/jest"]
+	},
+	"exclude": ["node_modules", "dist"]
+}

--- a/cf/latest-snapshot/wrangler.toml
+++ b/cf/latest-snapshot/wrangler.toml
@@ -1,0 +1,13 @@
+name = "forest-latest-snapshot"
+main = "./src/index.ts"
+
+compatibility_date = "2022-06-30"
+
+routes = [
+    { pattern = "forest-archive.chainsafe.dev/latest/calibnet/", zone_name = "chainsafe.dev" },
+    { pattern = "forest-archive.chainsafe.dev/latest/mainnet/", zone_name = "chainsafe.dev" },
+]
+
+[[r2_buckets]]
+binding = 'FOREST_ARCHIVE'     # can be any valid JavaScript variable name
+bucket_name = 'forest-archive'


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Define `https://forest-archive.chainsafe.dev/latest/calibnet/` and `https://forest-archive.chainsafe.dev/latest/mainnet/`.
- Both endpoints return the snapshot data directly without any redirects.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
