### PR TITLE
disable daily benchmark

### DIFF
--- a/.github/workflows/deploy-benchmark.yml
+++ b/.github/workflows/deploy-benchmark.yml
@@ -18,6 +18,8 @@ on:
 
 jobs:
   benchmark:
+    # The benchmark is flaky, disabling it until it works as intended.
+    if: false
     name: Benchmark Service
     runs-on: ubuntu-latest
     permissions: write-all


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- the benchmark droplet constantly gets re-created due to minor changes, while the entire benchmark is failing. Let's disable it for now until all issues are resolved.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
