### PR TITLE
Use Latest tag for Lotus

### DIFF
--- a/terraform/modules/benchmark/main.tf
+++ b/terraform/modules/benchmark/main.tf
@@ -83,9 +83,9 @@ resource "digitalocean_droplet" "forest" {
   region = var.region
   size   = var.size
   # Re-initialize resource if this hash changes:
-  user_data = join("-", [data.local_file.sources.content_sha256, sha256(join("", local.init_commands))])
-  tags      = ["iac"]
-  ssh_keys  = data.digitalocean_ssh_keys.keys.ssh_keys[*].fingerprint
+  user_data  = join("-", [data.local_file.sources.content_sha256, sha256(join("", local.init_commands))])
+  tags       = ["iac"]
+  ssh_keys   = data.digitalocean_ssh_keys.keys.ssh_keys[*].fingerprint
   monitoring = true
 
   graceful_shutdown = false

--- a/terraform/modules/benchmark/main.tf
+++ b/terraform/modules/benchmark/main.tf
@@ -69,6 +69,7 @@ locals {
     "echo 'export NEW_RELIC_ACCOUNT_ID=\"${var.NEW_RELIC_ACCOUNT_ID}\"' >> .forest_env",
     "echo 'export NEW_RELIC_REGION=\"${var.NEW_RELIC_REGION}\"' >> .forest_env",
     "echo 'export BASE_FOLDER=\"/chainsafe\"' >> .forest_env",
+    "echo 'export LOTUS_LATEST_TAG=\"${var.lotus_latest_tag}\"' >> .forest_env",
     "echo '. ~/.forest_env' >> .bashrc",
     ". ~/.forest_env",
     "nohup sh ./init.sh > init_log.txt &",

--- a/terraform/modules/benchmark/main.tf
+++ b/terraform/modules/benchmark/main.tf
@@ -86,6 +86,7 @@ resource "digitalocean_droplet" "forest" {
   user_data = join("-", [data.local_file.sources.content_sha256, sha256(join("", local.init_commands))])
   tags      = ["iac"]
   ssh_keys  = data.digitalocean_ssh_keys.keys.ssh_keys[*].fingerprint
+  monitoring = true
 
   graceful_shutdown = false
 

--- a/terraform/modules/benchmark/service/init.sh
+++ b/terraform/modules/benchmark/service/init.sh
@@ -15,6 +15,7 @@ sudo docker run --detach \
   --env BASE_FOLDER="$BASE_FOLDER" \
   --env SLACK_API_TOKEN="$SLACK_API_TOKEN" \
   --env SLACK_NOTIF_CHANNEL="$SLACK_NOTIF_CHANNEL" \
+  --env LOTUS_LATEST_TAG="$LOTUS_LATEST_TAG" \
   --restart unless-stopped \
   benchmark \
   /bin/bash -c "ruby run_benchmark.rb"

--- a/terraform/modules/benchmark/service/lotus_bench.rb
+++ b/terraform/modules/benchmark/service/lotus_bench.rb
@@ -41,7 +41,7 @@ class LotusBenchmark < BenchmarkBase
   end
 
   def checkout_command
-    exec_command(['git', 'checkout', ENV["LOTUS_LATEST_TAG"]])
+    exec_command(['git', 'checkout', ENV.fetch('LOTUS_LATEST_TAG')])
   end
 
   def clean_command

--- a/terraform/modules/benchmark/service/lotus_bench.rb
+++ b/terraform/modules/benchmark/service/lotus_bench.rb
@@ -41,11 +41,7 @@ class LotusBenchmark < BenchmarkBase
   end
 
   def checkout_command
-    if @chain == 'mainnet'
-      exec_command(%w[git checkout releases])
-    else
-      exec_command(%w[git checkout master])
-    end
+    exec_command(%w[git checkout release/v1.23.3])
   end
 
   def clean_command

--- a/terraform/modules/benchmark/service/lotus_bench.rb
+++ b/terraform/modules/benchmark/service/lotus_bench.rb
@@ -41,7 +41,7 @@ class LotusBenchmark < BenchmarkBase
   end
 
   def checkout_command
-    exec_command(%w[git checkout release/v1.23.3])
+    exec_command(['git', 'checkout', ENV["LOTUS_LATEST_TAG"]])
   end
 
   def clean_command

--- a/terraform/modules/benchmark/service/run_benchmark.rb
+++ b/terraform/modules/benchmark/service/run_benchmark.rb
@@ -29,6 +29,7 @@ SLACK_TOKEN = get_and_assert_env_variable 'SLACK_API_TOKEN'
 CHANNEL = get_and_assert_env_variable 'SLACK_NOTIF_CHANNEL'
 BASE_FOLDER = get_and_assert_env_variable 'BASE_FOLDER'
 SCRIPTS_DIR = get_and_assert_env_variable 'BASE_FOLDER'
+LOTUS_LATEST_TAG = get_and_assert_env_variable 'LOTUS_LATEST_TAG'
 LOG_DIR = "#{BASE_FOLDER}/logs"
 
 last_notification_date = nil

--- a/terraform/modules/benchmark/variable.tf
+++ b/terraform/modules/benchmark/variable.tf
@@ -84,7 +84,7 @@ variable "NEW_RELIC_REGION" {
 variable "lotus_latest_tag" {
   description = "The git tag of Lotus client for the benchmark"
   type        = string
-  # If you change from default do not forget to update the Go version in the Dockerfile.
   # Go version v1.19.12 or higher is needed for this version. Go version 1.20 is also supported, but 1.21 is NOT.
-  default     = "release/v1.23.3"
+  # If you change from default do not forget to update the Go version in the Dockerfile.
+  default = "release/v1.23.3"
 }

--- a/terraform/modules/benchmark/variable.tf
+++ b/terraform/modules/benchmark/variable.tf
@@ -80,3 +80,11 @@ variable "NEW_RELIC_REGION" {
   type        = string
   default     = "EU"
 }
+
+variable "lotus_latest_tag" {
+  description = "The git tag of Lotus client for the benchmark"
+  type        = string
+  # If you change from default do not forget to update the Go version in the Dockerfile.
+  # Go version v1.19.12 or higher is needed for this version. Go version 1.20 is also supported, but 1.21 is NOT.
+  default     = "release/v1.23.3"
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Use a fixed tag for Lotus to avoid any _surprises_
- Try add monitoring like we do for other services (sync check, snapshot export)


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #274


**Other information and links**
<!-- Add any other context about the pull request here. -->

We will start with [v1.23.3](https://github.com/filecoin-project/lotus/releases/tag/v1.23.3) and update it manually from time to time (so we can make sure nothing breaks, i.e. change in cli args).

<!-- Thank you 🔥 -->
