### PR TITLE
feat: download snapshots from preferred source

### DIFF
--- a/terraform/modules/daily_snapshot/service/daily_snapshot.rb
+++ b/terraform/modules/daily_snapshot/service/daily_snapshot.rb
@@ -29,8 +29,6 @@ client = SlackClient.new CHANNEL, SLACK_TOKEN
 # Find the snapshot with the most recent modification date
 all_snapshots = list_snapshots(CHAIN_NAME, BUCKET, ENDPOINT)
 unless all_snapshots.empty?
-  latest = all_snapshots.first
-
   # Sync and export snapshot
   snapshot_uploaded = system("bash -c 'timeout --signal=KILL 24h ./upload_snapshot.sh #{CHAIN_NAME}' > #{LOG_EXPORT} 2>&1")
 

--- a/terraform/modules/daily_snapshot/service/daily_snapshot.rb
+++ b/terraform/modules/daily_snapshot/service/daily_snapshot.rb
@@ -32,7 +32,7 @@ unless all_snapshots.empty?
   latest = all_snapshots.first
 
   # Sync and export snapshot
-  snapshot_uploaded = system("bash -c 'timeout --signal=KILL 24h ./upload_snapshot.sh #{CHAIN_NAME} #{latest.url}' > #{LOG_EXPORT} 2>&1")
+  snapshot_uploaded = system("bash -c 'timeout --signal=KILL 24h ./upload_snapshot.sh #{CHAIN_NAME}' > #{LOG_EXPORT} 2>&1")
 
   # Update our list of snapshots
   all_snapshots = list_snapshots(CHAIN_NAME, BUCKET, ENDPOINT)


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Let Forest decide on its own where to download snapshots from. This lets us move to CloudFlare when the next Forest version is released.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
