### PR TITLE
fix: make sure we're synced to the network before exporting a snapshot

### DIFF
--- a/terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -55,7 +55,9 @@ forest --config config.toml --chain "$CHAIN_NAME" --auto-download-snapshot --hal
 forest --config config.toml --chain "$CHAIN_NAME" --no-gc --save-token=token.txt --detach
 timeout "$SYNC_TIMEOUT" forest-cli --chain "$CHAIN_NAME" sync wait
 # Forest isn't waiting until fully synced. Tracking issue: https://github.com/ChainSafe/forest/issues/3540
-# Calling `sync wait` twice is a work-around.
+# Calling `sync wait` multiple times is a work-around.
+timeout "$SYNC_TIMEOUT" forest-cli --chain "$CHAIN_NAME" sync wait
+timeout "$SYNC_TIMEOUT" forest-cli --chain "$CHAIN_NAME" sync wait
 timeout "$SYNC_TIMEOUT" forest-cli --chain "$CHAIN_NAME" sync wait
 forest-cli --chain "$CHAIN_NAME" snapshot export -o forest_db/
 forest-cli --token=\$(cat token.txt) shutdown --force

--- a/terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -54,6 +54,9 @@ forest-tool db destroy --force --config config.toml --chain "$CHAIN_NAME"
 forest --config config.toml --chain "$CHAIN_NAME" --auto-download-snapshot --halt-after-import
 forest --config config.toml --chain "$CHAIN_NAME" --no-gc --save-token=token.txt --detach
 timeout "$SYNC_TIMEOUT" forest-cli --chain "$CHAIN_NAME" sync wait
+# Forest isn't waiting until fully synced. Tracking issue: https://github.com/ChainSafe/forest/issues/3540
+# Calling `sync wait` twice is a work-around.
+timeout "$SYNC_TIMEOUT" forest-cli --chain "$CHAIN_NAME" sync wait
 forest-cli --chain "$CHAIN_NAME" snapshot export -o forest_db/
 forest-cli --token=\$(cat token.txt) shutdown --force
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Workaround for a bug in `forest-cli sync wait`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
