### PR TITLE
improvement: use cheaper and faster droplet

### DIFF
--- a/terraform/daily_snapshot/main.tf
+++ b/terraform/daily_snapshot/main.tf
@@ -29,7 +29,7 @@ module "daily_snapshot" {
 
   # Configure service:
   name              = "forest-snapshot"       # droplet name
-  size              = "so-2vcpu-16gb"         # droplet size
+  size              = "s-4vcpu-16gb-amd"      # droplet size
   slack_channel     = "#forest-notifications" # slack channel for notifications
   snapshot_bucket   = "forest-snapshots"
   snapshot_endpoint = "fra1.digitaloceanspaces.com"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- the `s-4vcpu-16gb-amd` droplet is both cheaper and faster than `so-2vcpu-16gb` at exporting. Probably because the SSD is faster. This change should make snapshot exports 10-20 minutes faster.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
