### PR TITLE
fix: bump apt-get timeout from 30s to 90s

### DIFF
--- a/terraform/modules/daily_snapshot/service/init.sh
+++ b/terraform/modules/daily_snapshot/service/init.sh
@@ -6,8 +6,8 @@ set -eux
 export DEBIAN_FRONTEND=noninteractive
 
 # Use APT specific mechanism to wait for the lock
-apt-get -qqq --yes -o DPkg::Lock::Timeout=30 update
-apt-get -qqq --yes -o DPkg::Lock::Timeout=30 install -y ruby ruby-dev s3cmd anacron awscli
+apt-get -qqq --yes -o DPkg::Lock::Timeout=90 update
+apt-get -qqq --yes -o DPkg::Lock::Timeout=90 install -y ruby ruby-dev s3cmd anacron awscli
 
 # Install the gems
 gem install docker-api slack-ruby-client activesupport


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- increase apt-get timeout

With the previous timeout, I still frequently see:
```
+ export DEBIAN_FRONTEND=noninteractive
+ apt-get -qqq --yes -o DPkg::Lock::Timeout=30 update
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 1576 (apt-get)
E: Unable to lock directory /var/lib/apt/lists/
```



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
