### PR TITLE
fix: upload emergency snapshots to CF rather than DO

### DIFF
--- a/terraform/modules/daily_snapshot/service/upload_filops_snapshot.sh
+++ b/terraform/modules/daily_snapshot/service/upload_filops_snapshot.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 CHAIN="$1"
 
 # Ask curl for the filename of the snapshot
-SNAPSHOT_NAME=$(curl --remote-name --remote-header-name --write-out "%{filename_effective}" --silent https://forest-archive.chainsafe.dev/latest/$CHAIN/ -H "Range: bytes=0-0")
+SNAPSHOT_NAME=$(curl --remote-name --remote-header-name --write-out "%{filename_effective}" --silent https://forest-archive.chainsafe.dev/latest/"$CHAIN"/ -H "Range: bytes=0-0")
 rm -f "$SNAPSHOT_NAME"
 
 # Extract the date from the snapshot file name and


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- If no Forest snapshots are upload, upload a FilOps snapshot to CloudFlare rather than DO.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
