### PR TITLE
use cheaper droplet for the sync check

### DIFF
--- a/terraform/sync_check/main.tf
+++ b/terraform/sync_check/main.tf
@@ -29,7 +29,7 @@ module "sync_check" {
 
   # Configure service:
   name          = "forest-sync-check"     # droplet name
-  size          = "so-2vcpu-16gb"         # droplet size
+  size          = "s-4vcpu-16gb-amd"      # droplet size
   slack_channel = "#forest-notifications" # slack channel for notifications
 
   # Variable passthrough:


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- use a smaller VPS for the sync check, as discussed in https://github.com/ChainSafe/forest-iac/pull/289/files#r1345387699
- $47 saved each month ($131 before, $84 after)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->
https://slugs.do-api.dev/


<!-- Thank you 🔥 -->
