### PR TITLE
fix: exit if cron starts the export script twice

### DIFF
--- a/terraform/modules/daily_snapshot/service/mainnet_cron_job
+++ b/terraform/modules/daily_snapshot/service/mainnet_cron_job
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # shellcheck source=/dev/null
 source ~/.forest_env

--- a/terraform/modules/daily_snapshot/service/mainnet_cron_job
+++ b/terraform/modules/daily_snapshot/service/mainnet_cron_job
@@ -1,11 +1,10 @@
 #!/bin/bash
-set -e
 
 # shellcheck source=/dev/null
 source ~/.forest_env
 cd "$BASE_FOLDER" || exit
 while :
 do
-    flock -n /tmp/mainnet.lock -c "ruby daily_snapshot.rb mainnet > mainnet_log.txt 2>&1"
-    flock -n /tmp/mainnet_filops.lock -c "./upload_filops_snapshot.sh mainnet > filops_mainnet_log.txt 2>&1"
+    flock -n /tmp/mainnet.lock -c "ruby daily_snapshot.rb mainnet > mainnet_log.txt 2>&1" || exit
+    flock -n /tmp/mainnet_filops.lock -c "./upload_filops_snapshot.sh mainnet > filops_mainnet_log.txt 2>&1" || exit
 done


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- The mainnet script would accidentally enter an infinite loop if it was invoked more than once. After this PR, the script will exit if invoked twice.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
