### PR TITLE
fix: pin activesupport to version 7.0.8

### DIFF
--- a/terraform/modules/daily_snapshot/service/init.sh
+++ b/terraform/modules/daily_snapshot/service/init.sh
@@ -10,7 +10,8 @@ apt-get -qqq --yes -o DPkg::Lock::Timeout=90 update
 apt-get -qqq --yes -o DPkg::Lock::Timeout=90 install -y ruby ruby-dev anacron awscli
 
 # Install the gems
-gem install docker-api slack-ruby-client activesupport
+gem install docker-api slack-ruby-client
+gem install activesupport -v 7.0.8
 
 # 1. Configure aws
 # 2. Create forest_db directory


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- The new version of activesupport isn't backwards compatible



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
