### PR TITLE
fix: wait for cloud-init to finish

### DIFF
--- a/terraform/modules/daily_snapshot/service/init.sh
+++ b/terraform/modules/daily_snapshot/service/init.sh
@@ -2,12 +2,15 @@
 
 set -eux
 
+# Wait for cloud-init to finish initializing the machine
+cloud-init status --wait
+
 # Setting DEBIAN_FRONTEND to ensure non-interactive operations for APT
 export DEBIAN_FRONTEND=noninteractive
 
 # Use APT specific mechanism to wait for the lock
-apt-get -qqq --yes -o DPkg::Lock::Timeout=90 update
-apt-get -qqq --yes -o DPkg::Lock::Timeout=90 install -y ruby ruby-dev anacron awscli
+apt-get -qqq --yes update
+apt-get -qqq --yes install -y ruby ruby-dev anacron awscli
 
 # Install the gems
 gem install docker-api slack-ruby-client

--- a/terraform/modules/sync_check/service/init.sh
+++ b/terraform/modules/sync_check/service/init.sh
@@ -3,12 +3,15 @@
 ## Enable strict error handling, command tracing, and pipefail
 set -eux
 
+# Wait for cloud-init to finish initializing the machine
+cloud-init status --wait
+
 # Setting DEBIAN_FRONTEND to ensure non-interactive operations for APT
 export DEBIAN_FRONTEND=noninteractive
 
 # Use APT specific mechanism to wait for the lock
-apt-get -qqq --yes -o DPkg::Lock::Timeout=90 update
-apt-get -qqq --yes -o DPkg::Lock::Timeout=90 install -y ruby ruby-dev gcc make
+apt-get -qqq --yes update
+apt-get -qqq --yes install -y ruby ruby-dev gcc make
 
 gem install slack-ruby-client sys-filesystem
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Cloud-init clashes with our init script. We should wait for the machine to finish initializing before running our own script.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
