### PR TITLE
fix: suppress aws upload progress

### DIFF
--- a/terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -98,7 +98,7 @@ docker run \
   ghcr.io/chainsafe/forest:"${FOREST_TAG}" \
   -c "$COMMANDS" || exit 1
 
-aws --endpoint "$R2_ENDPOINT" s3 cp "$CHAIN_DB_DIR/forest_snapshot_$CHAIN_NAME"*.forest.car.zst s3://forest-archive/"$CHAIN_NAME"/latest/ || exit 1
+aws --endpoint "$R2_ENDPOINT" s3 cp --no-progress "$CHAIN_DB_DIR/forest_snapshot_$CHAIN_NAME"*.forest.car.zst s3://forest-archive/"$CHAIN_NAME"/latest/ || exit 1
 
 # Delete snapshot files
 rm "$CHAIN_DB_DIR/forest_snapshot_$CHAIN_NAME"*


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Don't show progress when uploading to CloudFlare.
- `aws-cli` likes to generate tens of MiBs of progress messages which aren't useful and just spam the logs.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
