### PR TITLE
chore: generate at most 1 mainnet snapshot per hour

### DIFF
--- a/terraform/modules/daily_snapshot/service/mainnet_cron_job
+++ b/terraform/modules/daily_snapshot/service/mainnet_cron_job
@@ -3,8 +3,5 @@
 # shellcheck source=/dev/null
 source ~/.forest_env
 cd "$BASE_FOLDER" || exit
-while :
-do
-    flock -n /tmp/mainnet.lock -c "ruby daily_snapshot.rb mainnet > mainnet_log.txt 2>&1" || exit
-    flock -n /tmp/mainnet_filops.lock -c "./upload_filops_snapshot.sh mainnet > filops_mainnet_log.txt 2>&1" || exit
-done
+flock -n /tmp/mainnet.lock -c "ruby daily_snapshot.rb mainnet > mainnet_log.txt 2>&1" || exit
+flock -n /tmp/mainnet_filops.lock -c "./upload_filops_snapshot.sh mainnet > filops_mainnet_log.txt 2>&1" || exit


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Turns out we don't need that many mainnet snapshots. One per hour is enough.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
