### PR TITLE
Revert "fix: use terraform latest version"

### DIFF
--- a/composite-action/terraform/action.yml
+++ b/composite-action/terraform/action.yml
@@ -40,7 +40,7 @@ runs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: v1.6.1
+        terraform_version: v1.5.7
 
     - name: Terraform Init
       run: terraform init

--- a/terraform/daily_snapshot/main.tf
+++ b/terraform/daily_snapshot/main.tf
@@ -14,14 +14,12 @@ terraform {
     region = "us-west-1"
     # The S3 region is determined by the endpoint. fra1 = Frankfurt.
     # This region does not have to be shared by the droplet.
-    endpoints = {
-      s3 = "https://fra1.digitaloceanspaces.com"
-    }
+    endpoint = "https://fra1.digitaloceanspaces.com"
+
     # Credentially can be validated through the Security Token Service (STS).
     # Unfortunately, DigitalOcean does not support STS so we have to skip the
     # validation.
     skip_credentials_validation = "true"
-    skip_requesting_account_id  = "true"
   }
 }
 

--- a/terraform/forest-calibnet/main.tf
+++ b/terraform/forest-calibnet/main.tf
@@ -2,15 +2,12 @@ terraform {
   required_version = ">= 1.2"
 
   backend "s3" {
-    bucket = "forest-iac"
-    key    = "forest-calibnet/terraform.tfstate"
-    region = "us-west-1"
-    endpoints = {
-      s3 = "https://fra1.digitaloceanspaces.com"
-    }
+    bucket                      = "forest-iac"
+    key                         = "forest-calibnet/terraform.tfstate"
+    region                      = "us-west-1"
+    endpoint                    = "fra1.digitaloceanspaces.com"
     skip_credentials_validation = true
     skip_metadata_api_check     = true
-    skip_requesting_account_id  = true
   }
 }
 

--- a/terraform/forest-mainnet/main.tf
+++ b/terraform/forest-mainnet/main.tf
@@ -2,15 +2,12 @@ terraform {
   required_version = "~> 1.3"
 
   backend "s3" {
-    bucket = "forest-iac"
-    key    = "forest_mainnet/terraform.tfstate"
-    region = "us-west-1"
-    endpoints = {
-      s3 = "https://fra1.digitaloceanspaces.com"
-    }
+    bucket                      = "forest-iac"
+    key                         = "forest_mainnet/terraform.tfstate"
+    region                      = "us-west-1"
+    endpoint                    = "fra1.digitaloceanspaces.com"
     skip_credentials_validation = true
     skip_metadata_api_check     = true
-    skip_requesting_account_id  = true
   }
 }
 

--- a/terraform/new-relic/main.tf
+++ b/terraform/new-relic/main.tf
@@ -10,15 +10,12 @@ terraform {
     }
   }
   backend "s3" {
-    bucket = "forest-iac"
-    key    = "new_relic/terraform.tfstate"
-    region = "us-west-1"
-    endpoints = {
-      s3 = "https://fra1.digitaloceanspaces.com"
-    }
+    bucket                      = "forest-iac"
+    key                         = "new_relic/terraform.tfstate"
+    region                      = "us-west-1"
+    endpoint                    = "fra1.digitaloceanspaces.com"
     skip_credentials_validation = true
     skip_metadata_api_check     = true
-    skip_requesting_account_id  = true
   }
 }
 

--- a/terraform/sync_check/main.tf
+++ b/terraform/sync_check/main.tf
@@ -14,15 +14,12 @@ terraform {
     region = "us-west-1"
     # The S3 region is determined by the endpoint. fra1 = Frankfurt.
     # This region does not have to be shared by the droplet.
-    endpoints = {
-      s3 = "fra1.digitaloceanspaces.com"
-    }
+    endpoint = "https://fra1.digitaloceanspaces.com"
 
     # Credentially can be validated through the Security Token Service (STS).
     # Unfortunately, DigitalOcean does not support STS so we have to skip the
     # validation.
     skip_credentials_validation = "true"
-    skip_requesting_account_id  = "true"
   }
 }
 


### PR DESCRIPTION
Reverts ChainSafe/forest-iac#312

Still our current terraform config can’t work with the new terraform `1.6.x` versions because there seems to still be a bug in the new update as stated [here](https://github.com/hashicorp/terraform/issues/34053), While we wait for a response from the HashiCorp team, we should reverts ChainSafe/forest-iac#312 to fix the failing CI
