### PR TITLE
chore: lower timeout when exporting snapshots

### DIFF
--- a/terraform/modules/daily_snapshot/service/daily_snapshot.rb
+++ b/terraform/modules/daily_snapshot/service/daily_snapshot.rb
@@ -46,7 +46,7 @@ date_before_export = latest_snapshot_date(CHAIN_NAME)
 add_timestamps_cmd = "awk '{ if ($0 !~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{6}Z/) print strftime(\"[%Y-%m-%d %H:%M:%S]\"), $0; else print $0; fflush(); }'"
 
 # Sync and export snapshot
-snapshot_uploaded = system("bash -c 'timeout --signal=KILL 24h ./upload_snapshot.sh #{CHAIN_NAME} #{LOG_EXPORT_DAEMON} #{LOG_EXPORT_METRICS}' | #{add_timestamps_cmd} > #{LOG_EXPORT_SCRIPT_RUN} 2>&1")
+snapshot_uploaded = system("bash -c 'timeout --signal=KILL 8h ./upload_snapshot.sh #{CHAIN_NAME} #{LOG_EXPORT_DAEMON} #{LOG_EXPORT_METRICS}' | #{add_timestamps_cmd} > #{LOG_EXPORT_SCRIPT_RUN} 2>&1")
 
 if snapshot_uploaded
   date_after_export = latest_snapshot_date(CHAIN_NAME)

--- a/terraform/modules/daily_snapshot/service/daily_snapshot.rb
+++ b/terraform/modules/daily_snapshot/service/daily_snapshot.rb
@@ -46,7 +46,7 @@ date_before_export = latest_snapshot_date(CHAIN_NAME)
 add_timestamps_cmd = "awk '{ if ($0 !~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{6}Z/) print strftime(\"[%Y-%m-%d %H:%M:%S]\"), $0; else print $0; fflush(); }'"
 
 # Sync and export snapshot
-snapshot_uploaded = system("bash -c 'timeout --signal=KILL 8h ./upload_snapshot.sh #{CHAIN_NAME} #{LOG_EXPORT_DAEMON} #{LOG_EXPORT_METRICS}' | #{add_timestamps_cmd} > #{LOG_EXPORT_SCRIPT_RUN} 2>&1")
+snapshot_uploaded = system("set -o pipefail && bash -c 'timeout --signal=KILL 8h ./upload_snapshot.sh #{CHAIN_NAME} #{LOG_EXPORT_DAEMON} #{LOG_EXPORT_METRICS}' | #{add_timestamps_cmd} > #{LOG_EXPORT_SCRIPT_RUN} 2>&1")
 
 if snapshot_uploaded
   date_after_export = latest_snapshot_date(CHAIN_NAME)

--- a/terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# If Forest hasn't synced to the network after 8 hours, something has gone wrong.
-SYNC_TIMEOUT=8h
+# If Forest hasn't synced to the network after 3 hours, something has gone wrong.
+SYNC_TIMEOUT=3h
 
 if [[ $# != 3 ]]; then
   echo "Usage: bash $0 CHAIN_NAME LOG_EXPORT_DAEMON LOG_EXPORT_METRICS"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Exporting a calibnet snapshot takes minutes, and a mainnet snapshot takes roughly an hour (sync+export+upload).
- Lower the hard timeout to 8 hours and the sync timeout to 3 hours.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
