### PR TITLE
mark secret variables as sensitive

### DIFF
--- a/terraform/daily_snapshot/prod/variable.tf
+++ b/terraform/daily_snapshot/prod/variable.tf
@@ -1,29 +1,35 @@
 variable "do_token" {
   description = "Token for authentication."
   type        = string
+  sensitive   = true
 }
 
 variable "R2_ACCESS_KEY" {
   description = "S3 access key id"
   type        = string
+  sensitive   = true
 }
 
 variable "R2_SECRET_KEY" {
   description = "S3 private access key"
   type        = string
+  sensitive   = true
 }
 
 variable "slack_token" {
   description = "slack access token"
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_API_KEY" {
   description = "New Relic API KEY"
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_ACCOUNT_ID" {
   description = "The New Relic Account ID"
   type        = string
+  sensitive   = true
 }

--- a/terraform/daily_snapshot/variable.tf
+++ b/terraform/daily_snapshot/variable.tf
@@ -1,19 +1,23 @@
 variable "do_token" {
   description = "Token for authentication."
   type        = string
+  sensitive   = true
 }
 
 variable "R2_ACCESS_KEY" {
   description = "S3 access key id"
   type        = string
+  sensitive   = true
 }
 
 variable "R2_SECRET_KEY" {
   description = "S3 private access key"
   type        = string
+  sensitive   = true
 }
 
 variable "slack_token" {
   description = "slack access token"
   type        = string
+  sensitive   = true
 }

--- a/terraform/forest-calibnet/variable.tf
+++ b/terraform/forest-calibnet/variable.tf
@@ -31,6 +31,7 @@ variable "source_addresses" {
 variable "do_token" {
   description = "Token for authentication."
   type        = string
+  sensitive   = true
 }
 
 variable "destination_addresses" {
@@ -56,14 +57,17 @@ variable "fw_name" {
 variable "NR_LICENSE_KEY" {
   description = "New Relic Access Token"
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_API_KEY" {
   description = "New Relic API KEY"
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_ACCOUNT_ID" {
   description = "The New Relic Account ID"
   type        = string
+  sensitive   = true
 }

--- a/terraform/forest-mainnet/variable.tf
+++ b/terraform/forest-mainnet/variable.tf
@@ -31,6 +31,7 @@ variable "source_addresses" {
 variable "do_token" {
   description = "Token for authentication."
   type        = string
+  sensitive   = true
 }
 
 variable "volume_size" {
@@ -71,14 +72,17 @@ variable "fw_name" {
 variable "NR_LICENSE_KEY" {
   description = "New Relic Access Token"
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_API_KEY" {
   description = "The New Relic API KEY"
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_ACCOUNT_ID" {
   description = "The New Relic Account ID"
   type        = string
+  sensitive   = true
 }

--- a/terraform/modules/daily_snapshot/variable.tf
+++ b/terraform/modules/daily_snapshot/variable.tf
@@ -1,6 +1,7 @@
 variable "digitalocean_token" {
   description = "Token for authentication."
   type        = string
+  sensitive   = true
 }
 
 variable "name" {
@@ -21,16 +22,19 @@ variable "slack_channel" {
 variable "slack_token" {
   description = "slack access token"
   type        = string
+  sensitive   = true
 }
 
 variable "R2_ACCESS_KEY" {
   description = "S3 access key id"
   type        = string
+  sensitive   = true
 }
 
 variable "R2_SECRET_KEY" {
   description = "S3 private access key"
   type        = string
+  sensitive   = true
 }
 
 variable "snapshot_bucket" {
@@ -96,10 +100,12 @@ variable "NEW_RELIC_API_KEY" {
   description = "New Relic API KEY"
   default     = ""
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_ACCOUNT_ID" {
   description = "The New Relic Account ID"
   default     = ""
   type        = string
+  sensitive   = true
 }

--- a/terraform/modules/filecoin_node/variable.tf
+++ b/terraform/modules/filecoin_node/variable.tf
@@ -31,6 +31,7 @@ variable "source_addresses" {
 variable "do_token" {
   description = "Token for authentication."
   type        = string
+  sensitive   = true
 }
 
 variable "volume_size" {
@@ -85,18 +86,21 @@ variable "NR_LICENSE_KEY" {
   description = "New Relic Access Token"
   default     = ""
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_API_KEY" {
   description = "New Relic API KEY"
   default     = ""
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_ACCOUNT_ID" {
   description = "New Relic Account ID"
   default     = ""
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_REGION" {

--- a/terraform/modules/sync_check/variable.tf
+++ b/terraform/modules/sync_check/variable.tf
@@ -1,6 +1,7 @@
 variable "digitalocean_token" {
   description = "Token for authentication."
   type        = string
+  sensitive   = true
 }
 
 variable "name" {
@@ -21,6 +22,7 @@ variable "slack_channel" {
 variable "slack_token" {
   description = "slack access token"
   type        = string
+  sensitive   = true
 }
 
 variable "image" {
@@ -51,10 +53,12 @@ variable "NEW_RELIC_API_KEY" {
   description = "New Relic API KEY"
   default     = ""
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_ACCOUNT_ID" {
   description = "The New Relic Account ID"
   default     = ""
   type        = string
+  sensitive   = true
 }

--- a/terraform/new-relic/variable.tf
+++ b/terraform/new-relic/variable.tf
@@ -1,11 +1,13 @@
 variable "NEW_RELIC_ACCOUNT_ID" {
   type        = string
   description = "The New Relic Account ID"
+  sensitive   = true
 }
 
 variable "NEW_RELIC_API_KEY" {
   description = "The New Relic API KEY"
   type        = string
+  sensitive   = true
 }
 
 variable "slack_destination_id" {

--- a/terraform/sync_check/variable.tf
+++ b/terraform/sync_check/variable.tf
@@ -1,19 +1,23 @@
 variable "do_token" {
   description = "Token for authentication."
   type        = string
+  sensitive   = true
 }
 
 variable "slack_token" {
   description = "slack access token"
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_API_KEY" {
   description = "New Relic API KEY"
   type        = string
+  sensitive   = true
 }
 
 variable "NEW_RELIC_ACCOUNT_ID" {
   description = "The New Relic Account ID"
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Applying some sensible practices from the TF book: make secrets in Terraform variables sensitive so they are not logged when running `plan` or `apply`. This reduces the chance of an accidental secret leak.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->
https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables


<!-- Thank you 🔥 -->
