### PR TITLE
minimize downtime during new deployments

### DIFF
--- a/terraform/modules/daily_snapshot/main.tf
+++ b/terraform/modules/daily_snapshot/main.tf
@@ -114,6 +114,10 @@ resource "digitalocean_droplet" "forest" {
   provisioner "remote-exec" {
     inline = local.init_commands
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 

--- a/terraform/modules/filecoin_node/main.tf
+++ b/terraform/modules/filecoin_node/main.tf
@@ -62,6 +62,10 @@ resource "digitalocean_droplet" "forest" {
   })
 
   tags = [var.chain]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "digitalocean_volume" "forest_volume" {

--- a/terraform/modules/sync_check/main.tf
+++ b/terraform/modules/sync_check/main.tf
@@ -112,6 +112,10 @@ resource "digitalocean_droplet" "forest" {
   provisioner "remote-exec" {
     inline = local.init_commands
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 data "digitalocean_project" "forest_project" {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- this [lifecycle](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#syntax-and-arguments) option should minimize the downtime caused by re-deployments by first creating the new service and only then scraping the old one.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
