### PR TITLE
allow no trailing slash latest snapshot link

### DIFF
--- a/cf/latest-snapshot/wrangler.toml
+++ b/cf/latest-snapshot/wrangler.toml
@@ -4,8 +4,8 @@ main = "./src/index.ts"
 compatibility_date = "2022-06-30"
 
 routes = [
-    { pattern = "forest-archive.chainsafe.dev/latest/calibnet/", zone_name = "chainsafe.dev" },
-    { pattern = "forest-archive.chainsafe.dev/latest/mainnet/", zone_name = "chainsafe.dev" },
+    { pattern = "forest-archive.chainsafe.dev/latest/calibnet", zone_name = "chainsafe.dev" },
+    { pattern = "forest-archive.chainsafe.dev/latest/mainnet", zone_name = "chainsafe.dev" },
 ]
 
 [[r2_buckets]]

--- a/cf/latest-snapshot/wrangler.toml
+++ b/cf/latest-snapshot/wrangler.toml
@@ -6,6 +6,8 @@ compatibility_date = "2022-06-30"
 routes = [
     { pattern = "forest-archive.chainsafe.dev/latest/calibnet", zone_name = "chainsafe.dev" },
     { pattern = "forest-archive.chainsafe.dev/latest/mainnet", zone_name = "chainsafe.dev" },
+    { pattern = "forest-archive.chainsafe.dev/latest/calibnet/", zone_name = "chainsafe.dev" },
+    { pattern = "forest-archive.chainsafe.dev/latest/mainnet/", zone_name = "chainsafe.dev" },
 ]
 
 [[r2_buckets]]


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- allow links without trailing slashes. Both `wget https://forest-archive.chainsafe.dev/latest/calibnet` and `wget https://forest-archive.chainsafe.dev/latest/calibnet/` should work now.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest-iac/issues/286


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
