### PR TITLE
remove --chain for forest-cli invocations

### DIFF
--- a/terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -63,13 +63,13 @@ forest-tool db destroy --force --config config.toml --chain "$CHAIN_NAME"
 
 forest --config config.toml --chain "$CHAIN_NAME" --auto-download-snapshot --halt-after-import
 forest --config config.toml --chain "$CHAIN_NAME" --no-gc --save-token=token.txt --detach
-timeout "$SYNC_TIMEOUT" forest-cli --chain "$CHAIN_NAME" sync wait
+timeout "$SYNC_TIMEOUT" forest-cli sync wait
 # Forest isn't waiting until fully synced. Tracking issue: https://github.com/ChainSafe/forest/issues/3540
 # Calling 'sync wait' multiple times is a work-around.
-timeout "$SYNC_TIMEOUT" forest-cli --chain "$CHAIN_NAME" sync wait
-timeout "$SYNC_TIMEOUT" forest-cli --chain "$CHAIN_NAME" sync wait
-timeout "$SYNC_TIMEOUT" forest-cli --chain "$CHAIN_NAME" sync wait
-forest-cli --chain "$CHAIN_NAME" snapshot export -o forest_db/
+timeout "$SYNC_TIMEOUT" forest-cli sync wait
+timeout "$SYNC_TIMEOUT" forest-cli sync wait
+timeout "$SYNC_TIMEOUT" forest-cli sync wait
+forest-cli snapshot export -o forest_db/
 forest-cli --token=\$(cat token.txt) shutdown --force
 
 # Run full checks only for calibnet, given that it takes too long for mainnet.


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- the newest release doesn't support `--chain` for `forest-cli`. This fixes
```
+ timeout 3h forest-cli --chain mainnet sync wait
error: unexpected argument '--chain' found
```



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
