### PR TITLE
pin daily snapshot to forest:v0.15.0

### DIFF
--- a/terraform/daily_snapshot/prod/main.tf
+++ b/terraform/daily_snapshot/prod/main.tf
@@ -32,7 +32,7 @@ module "daily_snapshot" {
   size            = "s-4vcpu-16gb-amd"      # droplet size
   slack_channel   = "#forest-notifications" # slack channel for notifications
   snapshot_bucket = "forest-archive"
-  forest_tag      = "latest"
+  forest_tag      = "v0.15.0"
   r2_endpoint     = "https://2238a825c5aca59233eab1f221f7aefb.r2.cloudflarestorage.com/"
 
   # Variable passthrough:


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- pins the snapshot service to `v0.15.0` image of Forest. This is so that Forest breaking releases don't knock-out the service if it's not updated beforehand.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
