### PR TITLE
fix daily snapshot endpoint

### DIFF
--- a/terraform/daily_snapshot/prod/main.tf
+++ b/terraform/daily_snapshot/prod/main.tf
@@ -14,12 +14,15 @@ terraform {
     region = "us-west-1"
     # The S3 region is determined by the endpoint. fra1 = Frankfurt.
     # This region does not have to be shared by the droplet.
-    endpoint = "https://fra1.digitaloceanspaces.com"
+    endpoints = {
+      s3 = "https://fra1.digitaloceanspaces.com"
+    }
 
     # Credentially can be validated through the Security Token Service (STS).
     # Unfortunately, DigitalOcean does not support STS so we have to skip the
     # validation.
     skip_credentials_validation = "true"
+    skip_requesting_account_id  = "true"
     skip_s3_checksum            = "true"
   }
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- apparently, a revert https://github.com/ChainSafe/forest-iac/pull/327/commits/d3c24a2f6d8f9edd85c7a4c183c85ccf89d5f5b8 didn't include all necessary changes.

This should fix:
```
│ Warning: Deprecated Parameter
│ 
│   on main.tf line 17, in terraform:
│   17:     endpoint = "https://fra1.digitaloceanspaces.com"
│ 
│ The parameter "endpoint" is deprecated. Use parameter "endpoints.s3"
│ instead.
╵

╷
│ Error: Retrieving AWS account details: AWS account ID not previously found and failed retrieving via all available methods. See https://www.terraform.io/docs/providers/aws/index.html#skip_requesting_account_id for workaround and implications. Errors: 2 errors occurred:
│ 	* retrieving caller identity from STS: operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: b0a61ffd-4ecd-4b6e-a485-f63e7[44](https://github.com/ChainSafe/forest-iac/actions/runs/6743361800/job/18331182857#step:3:47)ef566, api error InvalidClientTokenId: The security token included in the request is invalid.
│ 	* retrieving account information via iam:ListRoles: operation error IAM: ListRoles, https response error StatusCode: 403, RequestID: a90f0dc2-d7fd-4ac6-9786-[45](https://github.com/ChainSafe/forest-iac/actions/runs/6743361800/job/18331182857#step:3:48)2981fadf6c, api error InvalidClientTokenId: The security token included in the request is invalid.
│
```

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
