### PR TITLE
add accountid to cf deployments + workflow dispatch

### DIFF
--- a/.github/workflows/deploy-cf-latest-snapshot.yml
+++ b/.github/workflows/deploy-cf-latest-snapshot.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'cf/latest-snapshot'
       - '.github/workflows/deploy-cf-latest-snapshot.yml'
+  workflow_dispatch:
 
 jobs:
   check-and-deploy:

--- a/.github/workflows/deploy-cf-latest-snapshot.yml
+++ b/.github/workflows/deploy-cf-latest-snapshot.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Deployment check
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: "cf/latest-snapshot"
           command: deploy --dry-run
       - name: Deploy
         if: github.ref == 'refs/heads/main' && ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' )
         uses: cloudflare/wrangler-action@v3
         with:
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: "cf/latest-snapshot"

--- a/.github/workflows/deploy-cf-prune-latest.yml
+++ b/.github/workflows/deploy-cf-prune-latest.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'cf/prune-latest'
       - '.github/workflows/deploy-cf-prune-latest.yml'
+  workflow_dispatch:
 
 jobs:
   check-and-deploy:

--- a/.github/workflows/deploy-cf-prune-latest.yml
+++ b/.github/workflows/deploy-cf-prune-latest.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Deployment check
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: "cf/prune-latest"
           command: deploy --dry-run
       - name: Deploy
         if: github.ref == 'refs/heads/main' && ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' )
         uses: cloudflare/wrangler-action@v3
         with:
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: "cf/prune-latest"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- add account id to CF deployments, given the profile from which the token was generated has multiple accounts.
- allow manually running CF deployments via workflow dispatch



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
