### PR TITLE
bump Forest version for daily snapshot

### DIFF
--- a/terraform/daily_snapshot/prod/main.tf
+++ b/terraform/daily_snapshot/prod/main.tf
@@ -36,7 +36,7 @@ module "daily_snapshot" {
   size            = "s-4vcpu-16gb-amd"      # droplet size
   slack_channel   = "#forest-notifications" # slack channel for notifications
   snapshot_bucket = "forest-archive"
-  forest_tag      = "v0.15.0"
+  forest_tag      = "v0.15.2"
   r2_endpoint     = "https://2238a825c5aca59233eab1f221f7aefb.r2.cloudflarestorage.com/"
 
   # Variable passthrough:


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- bumped version of Forest for the daily snapshot service. This is required for a smooth transition between Watermelon and WatermelonFix for the calibration network. See https://github.com/ChainSafe/forest/issues/3632 for more details.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
