### PR TITLE
push latest-snapshot logs to cloudflare

### DIFF
--- a/cf/latest-snapshot/wrangler.toml
+++ b/cf/latest-snapshot/wrangler.toml
@@ -2,6 +2,7 @@ name = "forest-latest-snapshot"
 main = "./src/index.ts"
 
 compatibility_date = "2022-06-30"
+logpush = true
 
 routes = [
     { pattern = "forest-archive.chainsafe.dev/latest/calibnet", zone_name = "chainsafe.dev" },


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- push the worker logs for the latest snapshot, for analytics

![image](https://github.com/ChainSafe/forest-iac/assets/9642092/1e30832c-8462-46fa-b6e0-ba16ac0db8dc)


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
