### PR TITLE
chore: use latest forest image tag for snapshot service

### DIFF
--- a/terraform/daily_snapshot/prod/main.tf
+++ b/terraform/daily_snapshot/prod/main.tf
@@ -36,7 +36,7 @@ module "daily_snapshot" {
   size            = "s-4vcpu-16gb-amd"      # droplet size
   slack_channel   = "#forest-notifications" # slack channel for notifications
   snapshot_bucket = "forest-archive"
-  forest_tag      = "2023-11-14-ddbdbb7"
+  forest_tag      = "latest"
   r2_endpoint     = "https://2238a825c5aca59233eab1f221f7aefb.r2.cloudflarestorage.com/"
 
   # Variable passthrough:

--- a/terraform/daily_snapshot/prod/main.tf
+++ b/terraform/daily_snapshot/prod/main.tf
@@ -36,7 +36,7 @@ module "daily_snapshot" {
   size            = "s-4vcpu-16gb-amd"      # droplet size
   slack_channel   = "#forest-notifications" # slack channel for notifications
   snapshot_bucket = "forest-archive"
-  forest_tag      = "2023-11-19-911daab"
+  forest_tag      = "v0.16.1"
   r2_endpoint     = "https://2238a825c5aca59233eab1f221f7aefb.r2.cloudflarestorage.com/"
 
   # Variable passthrough:

--- a/terraform/daily_snapshot/prod/main.tf
+++ b/terraform/daily_snapshot/prod/main.tf
@@ -36,7 +36,7 @@ module "daily_snapshot" {
   size            = "s-4vcpu-16gb-amd"      # droplet size
   slack_channel   = "#forest-notifications" # slack channel for notifications
   snapshot_bucket = "forest-archive"
-  forest_tag      = "latest"
+  forest_tag      = "2023-11-19-911daab"
   r2_endpoint     = "https://2238a825c5aca59233eab1f221f7aefb.r2.cloudflarestorage.com/"
 
   # Variable passthrough:


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Switch back to the ~`latest`~ `v0.16.1` image tag, as `forest@0.16.1` contains necessary fixes/mitigations for the performance issue.

~Let's merge this after `forest@0.16.1` is published.~

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
