### PR TITLE
Use faster droplet for snapshot service

### DIFF
--- a/terraform/daily_snapshot/main.tf
+++ b/terraform/daily_snapshot/main.tf
@@ -32,7 +32,7 @@ module "daily_snapshot" {
 
   # Configure service:
   name              = "forest-snapshot-dev" # droplet name
-  size              = "s-4vcpu-16gb-amd"    # droplet size
+  size              = "c2-8vcpu-16gb"       # droplet size
   slack_channel     = "#forest-dump"        # slack channel for notifications
   snapshot_bucket   = "forest-archive-dev"
   snapshot_endpoint = "fra1.digitaloceanspaces.com"

--- a/terraform/daily_snapshot/prod/main.tf
+++ b/terraform/daily_snapshot/prod/main.tf
@@ -33,7 +33,7 @@ module "daily_snapshot" {
 
   # Configure service:
   name            = "forest-snapshot"       # droplet name
-  size            = "s-4vcpu-16gb-amd"      # droplet size
+  size            = "c2-8vcpu-16gb"         # droplet size
   slack_channel   = "#forest-notifications" # slack channel for notifications
   snapshot_bucket = "forest-archive"
   forest_tag      = "v0.16.1"

--- a/terraform/modules/daily_snapshot/service/upload_snapshot.sh
+++ b/terraform/modules/daily_snapshot/service/upload_snapshot.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# If Forest hasn't synced to the network after 3 hours, something has gone wrong.
-SYNC_TIMEOUT=3h
+# If Forest hasn't synced to the network after 6 hours, something has gone wrong.
+SYNC_TIMEOUT=6h
 
 if [[ $# != 3 ]]; then
   echo "Usage: bash $0 CHAIN_NAME LOG_EXPORT_DAEMON LOG_EXPORT_METRICS"
@@ -66,11 +66,6 @@ forest-tool db destroy --force --config config.toml --chain "$CHAIN_NAME"
 
 forest --config config.toml --chain "$CHAIN_NAME" --auto-download-snapshot --halt-after-import
 forest --config config.toml --chain "$CHAIN_NAME" --no-gc --save-token=token.txt --detach
-timeout "$SYNC_TIMEOUT" forest-cli sync wait
-# Forest isn't waiting until fully synced. Tracking issue: https://github.com/ChainSafe/forest/issues/3540
-# Calling 'sync wait' multiple times is a work-around.
-timeout "$SYNC_TIMEOUT" forest-cli sync wait
-timeout "$SYNC_TIMEOUT" forest-cli sync wait
 timeout "$SYNC_TIMEOUT" forest-cli sync wait
 forest-cli snapshot export -o forest_db/
 forest-cli --token=\$(cat token.txt) shutdown --force


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Use droplet with dedicated CPU resources rather than shared CPU resources.
- Remove work-around for a bug that was fixed.
- Increase sync timeout from 3h to 6h.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
