### PR TITLE
CF: redirect to archive when requesting latest snapshot

### DIFF
--- a/cf/latest-snapshot/src/index.ts
+++ b/cf/latest-snapshot/src/index.ts
@@ -36,7 +36,7 @@ async function get_latest(
 			// Response.redirect requires an absolute URL. Manually create the response to get around this.
 			return new Response('Found!', {
 				status: 302,
-				headers: { 'Location': '/archive/' + latest.key }
+				headers: { Location: '/archive/' + latest.key },
 			});
 		}
 		case SnapshotType.archive: {

--- a/cf/latest-snapshot/src/index.ts
+++ b/cf/latest-snapshot/src/index.ts
@@ -33,16 +33,11 @@ async function get_latest(
 				});
 			}
 
-			object = await env.FOREST_ARCHIVE.get(latest.key, {
-				range: req_headers,
-				onlyIf: req_headers,
+			// Response.redirect requires an absolute URL. Manually create the response to get around this.
+			return new Response('Found!', {
+				status: 302,
+				headers: { 'Location': '/archive/' + latest.key }
 			});
-			if (object === null) {
-				return new Response('No latest snapshot found', {
-					status: 404,
-				});
-			}
-			break;
 		}
 		case SnapshotType.archive: {
 			object = await env.FOREST_ARCHIVE.get(path, {


### PR DESCRIPTION
This lets people resume downloads even if new snapshots are uploaded.

**Summary of changes**
Changes introduced in this pull request:
- `/latest/{chain}/` now redirects to `/archive/{chain}/latest/{specific_file.forest.car.zst}`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
