### PR TITLE
fix: tell curl to follow indirections in the snapshot service

### DIFF
--- a/terraform/modules/daily_snapshot/service/daily_snapshot.rb
+++ b/terraform/modules/daily_snapshot/service/daily_snapshot.rb
@@ -16,7 +16,7 @@ CHANNEL = get_and_assert_env_variable 'SLACK_NOTIF_CHANNEL'
 # Query the date of the most recent snapshot.
 def latest_snapshot_date(chain_name = 'calibnet')
   # We do not support HEAD requests but we _do_ support empty ranges.
-  filename = `curl --remote-name --remote-header-name --write-out "%{filename_effective}" --silent https://forest-archive.chainsafe.dev/latest/#{chain_name}/ -H "Range: bytes=0-0"`
+  filename = `curl --remote-name --remote-header-name --location --write-out "%{filename_effective}" --silent https://forest-archive.chainsafe.dev/latest/#{chain_name}/ -H "Range: bytes=0-0"`
   # Curl will create a file with a single byte in it. Let's clean it up.
   File.delete(filename)
   snapshot_format = /^([^_]+?)_snapshot_(?<network>[^_]+?)_(?<date>\d{4}-\d{2}-\d{2})_height_(?<height>\d+)(\.forest)?\.car.zst$/


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- We recently introduced an indirection in the snapshot URL. This PR tells our snapshot service to follow indirections.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
