### PR TITLE
add pagerduty integration

### DIFF
--- a/.github/workflows/deploy-snapshot-monitoring.yml
+++ b/.github/workflows/deploy-snapshot-monitoring.yml
@@ -25,6 +25,8 @@ jobs:
       TF_VAR_slack_enable: true
       TF_VAR_slack_destination_id: ${{ secrets.SLACK_DESTINATION_ID }}
       TF_VAR_slack_channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
+      TF_VAR_pagerduty_enable: true
+      TF_VAR_pagerduty_destination_id: ${{ secrets.PAGERDUTY_DESTINATION_ID }}
     runs-on: ubuntu-latest
     permissions: write-all
     steps:

--- a/tf-managed/modules/snapshot-monitoring/README.md
+++ b/tf-managed/modules/snapshot-monitoring/README.md
@@ -10,3 +10,9 @@ Networks: `mainnet` and `calibnet`
 Checks:
 - asserts the epoch of the hosted snapshots is not older than a given threshold,
 - trigger alarms if more than 2/3 checks over an hour fail.
+
+## Alarm destinations
+
+All alarms are handled via NewRelic, which integrates other applications. For now, it's:
+* [PagerDuty](https://chainsafe.pagerduty.com/) - the provided destination is linked with a service generated there and visible in the [service direcory](https://chainsafe.pagerduty.com/service-directory). It will fire alarms to on-call engineers if enabled, so use it cautiously.
+* [Slack](https://api.slack.com/) - the provided destination is also linked with company Slack, and the `channel_id` governs the actual channel to which the notifications will go.

--- a/tf-managed/modules/snapshot-monitoring/provider.tf
+++ b/tf-managed/modules/snapshot-monitoring/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     newrelic = {
       source  = "newrelic/newrelic"
-      version = "~> 3.0"
+      version = "~> 3.5"
     }
   }
 }

--- a/tf-managed/modules/snapshot-monitoring/variable.tf
+++ b/tf-managed/modules/snapshot-monitoring/variable.tf
@@ -46,3 +46,19 @@ variable "slack_channel_id" {
   default     = ""
   sensitive   = true
 }
+
+variable "pagerduty_enable" {
+  description = "Enable PagerDuty notifications"
+  type        = bool
+  default     = false
+}
+
+# This needs to be created manually. Afterwards, it can be found in
+# NR / Alerts & AI / Destinations. Otherwise, we'd need special permissions
+# to create it via the API.
+variable "pagerduty_destination_id" {
+  description = "PagerDuty destination id"
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- added PagerDuty integration to the snapshot monitor
- we could provide a PagerDuty service, but we'd need an extra-privileged account (or get provided with a relevant API key). Given that it's too much of a hassle for our niche purpose, I created the PD destination manually. We might want to automatize in the future if need be.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/forest-iac/issues/381


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
