### PR TITLE
fix: use edge-fat tag in sync check service

### DIFF
--- a/tf-managed/modules/sync-check/main.tf
+++ b/tf-managed/modules/sync-check/main.tf
@@ -41,7 +41,7 @@ locals {
     NEW_RELIC_API_KEY         = var.NEW_RELIC_API_KEY,
     NEW_RELIC_ACCOUNT_ID      = var.NEW_RELIC_ACCOUNT_ID,
     NEW_RELIC_REGION          = var.NEW_RELIC_REGION,
-    forest_tag                = "edge"
+    forest_tag                = "edge-fat"
   })
 }
 


### PR DESCRIPTION
**Summary of changes**

Context: https://github.com/ChainSafe/forest/issues/3892
fat image is now available to save downloading proof parameter files(https://github.com/ChainSafe/forest/pull/3902) and actor bundle(https://github.com/ChainSafe/forest/pull/3904)

Changes introduced in this pull request:
- update `forest_tag` in sync check service to use `edge-fat`, see https://github.com/ChainSafe/forest/pkgs/container/forest



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
