### PR TITLE
increase calibnet snapshot validation timeout

### DIFF
--- a/tf-managed/modules/daily-snapshot/service/upload_snapshot.sh
+++ b/tf-managed/modules/daily-snapshot/service/upload_snapshot.sh
@@ -77,7 +77,7 @@ forest-cli --token=\$(cat token.txt) shutdown --force
 
 # Run full checks only for calibnet, given that it takes too long for mainnet.
 if [ "$CHAIN_NAME" = "calibnet" ]; then
-  timeout 5m forest-tool snapshot validate --check-network "$CHAIN_NAME" forest_db/forest_snapshot_*.forest.car.zst
+  timeout 30m forest-tool snapshot validate --check-network "$CHAIN_NAME" forest_db/forest_snapshot_*.forest.car.zst
 else
   forest-tool archive info forest_db/forest_snapshot_*.forest.car.zst
   timeout 30m forest-tool snapshot validate --check-links 0 --check-network "$CHAIN_NAME" --check-stateroots 5 forest_db/forest_snapshot_*.forest.car.zst


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- downloading proofs takes way too much time than expected. Five minutes is too optimistic. Increasing to 30 minutes.

Note: this should be resolved via https://github.com/ChainSafe/forest-iac/issues/364, given the image should contain all the needed artefacts (within reason). 300 MB worth of proofs is okay.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
