### PR TITLE
update snapshot service Forest to v0.16.6

### DIFF
--- a/tf-managed/live/environments/prod/applications/snapshot-service/terragrunt.hcl
+++ b/tf-managed/live/environments/prod/applications/snapshot-service/terragrunt.hcl
@@ -13,7 +13,7 @@ inputs = {
   name            = "forest-snapshot"
   size            = "s-4vcpu-16gb-amd"
   r2_endpoint     = "https://2238a825c5aca59233eab1f221f7aefb.r2.cloudflarestorage.com/"
-  forest_tag      = "v0.16.6"
+  forest_tag      = "v0.16.6-fat"
   snapshot_bucket = "forest-archive"
 
   monitoring = {

--- a/tf-managed/live/environments/prod/applications/snapshot-service/terragrunt.hcl
+++ b/tf-managed/live/environments/prod/applications/snapshot-service/terragrunt.hcl
@@ -13,7 +13,7 @@ inputs = {
   name            = "forest-snapshot"
   size            = "s-4vcpu-16gb-amd"
   r2_endpoint     = "https://2238a825c5aca59233eab1f221f7aefb.r2.cloudflarestorage.com/"
-  forest_tag      = "v0.16.4"
+  forest_tag      = "v0.16.6"
   snapshot_bucket = "forest-archive"
 
   monitoring = {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- update snapshot service Forest to v0.16.6 https://github.com/ChainSafe/forest/releases/tag/v0.16.6



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
