### PR TITLE
retry logic CF snapshots

### DIFF
--- a/images/snapshot-service/src/upload_snapshot.sh
+++ b/images/snapshot-service/src/upload_snapshot.sh
@@ -67,7 +67,9 @@ forest-tool db destroy --force --config config.toml --chain "$CHAIN_NAME"
 # Workaround for https://github.com/ChainSafe/forest/issues/3715
 # Normally, Forest should automatically download the latest snapshot. However, the performance
 # of the download gets randomly bad, and the download times out.
-aria2c -x5 https://forest-archive.chainsafe.dev/latest/$CHAIN_NAME/
+# Retry logic, because CF occassionally returns 500 (not 503) errors.
+for i in {1..5}; do aria2c -x5 https://forest-archive.chainsafe.dev/latest/$CHAIN_NAME/ && break || sleep 15; done
+
 forest --config config.toml --chain "$CHAIN_NAME" --consume-snapshot *.car.zst --halt-after-import
 
 forest --config config.toml --chain "$CHAIN_NAME" --no-gc --save-token=token.txt --target-peer-count 500 --detach


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Snapshot service occasionally fails with 500 from `aria2c`. This change introduces basic retry logic in case of any failures.
```
[2024-02-15 13:23:37] Aborted. Database path /home/forest/forest_db/mainnet is not a valid directory
+ aria2c -x5 https://forest-archive.chainsafe.dev/latest/mainnet/
[2024-02-15 13:23:37] 
[2024-02-15 13:23:37] 02/15 13:23:37 [[1;32mNOTICE[0m] Downloading 1 item(s)
[2024-02-15 13:23:46] [#ac5ec5 0B/0B CN:1 DL:0B]
[2024-02-15 13:23:46] [#ac5ec5 0B/0B CN:1 DL:0B]
[2024-02-15 13:23:46] [#ac5ec5 0B/0B CN:1 DL:0B]
[2024-02-15 13:23:46] [#ac5ec5 0B/0B CN:1 DL:0B]
[2024-02-15 13:23:46] [#ac5ec5 0B/0B CN:1 DL:0B]
[2024-02-15 13:23:46] [#ac5ec5 0B/0B CN:1 DL:0B]
[2024-02-15 13:23:46] [#ac5ec5 0B/0B CN:1 DL:0B]
[2024-02-15 13:23:46] [#ac5ec5 0B/0B CN:1 DL:0B]
[2024-02-15 13:23:46] 
[2024-02-15 13:23:46] 02/15 13:23:46 [[1;31mERROR[0m] CUID#7 - Download aborted. URI=https://forest-archive.chainsafe.dev/latest/mainnet/
[2024-02-15 13:23:46] Exception: [AbstractCommand.cc:351] errorCode=22 URI=https://forest-archive.chainsafe.dev/latest/mainnet/
[2024-02-15 13:23:46]   -> [HttpSkipResponseCommand.cc:239] errorCode=22 The response status is not successful. status=500
[2024-02-15 13:23:46] 
[2024-02-15 13:23:46] 02/15 13:23:46 [[1;32mNOTICE[0m] Download GID#ac5ec5e78e507e53 not complete: 
[2024-02-15 13:23:46] 
[2024-02-15 13:23:46] Download Results:
[2024-02-15 13:23:46] gid   |stat|avg speed  |path/URI
[2024-02-15 13:23:46] ======+====+===========+=======================================================
[2024-02-15 13:23:46] ac5ec5|ERR |       0B/s|https://forest-archive.chainsafe.dev/latest/mainnet/
[2024-02-15 13:23:46] 
[2024-02-15 13:23:46] Status Legend:
[2024-02-15 13:23:46] (ERR):error occurred.
[2024-02-15 13:23:46] 
[2024-02-15 13:23:46] aria2 will resume download if the transfer is restarted.
[2024-02-15 13:23:46] If there are any errors, then see the log file. See '-l' option in help/man page for details.
```


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
