### PR TITLE
fix(forest-droplet): publicly expose p2p port

### DIFF
--- a/tf-managed/modules/forest-droplet/bootstrap.bash.tftpl
+++ b/tf-managed/modules/forest-droplet/bootstrap.bash.tftpl
@@ -58,11 +58,13 @@ sudo --user="${NEW_USER}" -- \
   --volume=/home/"${NEW_USER}"/forest_data:/home/"${NEW_USER}"/forest_data:z \
   --publish=2345:2345 \
   --publish=6116:6116 \
+  --publish=12345:12345 \
   --restart=always \
   ghcr.io/chainsafe/forest:latest \
   --config=/home/"${NEW_USER}"/forest_data/config.toml \
   --encrypt-keystore false \
   --auto-download-snapshot \
+  --p2p-listen-address /ip4/0.0.0.0/tcp/12345 \
   --chain="${CHAIN}"
 
 # It monitors running Docker containers and watches for changes to the images that those containers were originally started from.

--- a/tf-managed/modules/forest-droplet/firewall.tf
+++ b/tf-managed/modules/forest-droplet/firewall.tf
@@ -9,9 +9,11 @@ resource "digitalocean_firewall" "forest_firewall" {
 
   dynamic "inbound_rule" {
     for_each = [
-      "22",   // SSH
-      "1234", // RPC
-      "80"    // HTTP
+      "22",    // SSH
+      "2345",  // RPC
+      "6116",  // Metrics
+      "80",    // HTTP
+      "12345", // P2P
     ]
     iterator = port
     content {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

- publicly expose p2p port (12345)
- publicly expose metrics port (6116)
- fix rpc port (1234 -> 2345)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
