### PR TITLE
NTP in snapshot services

### DIFF
--- a/tf-managed/modules/daily-snapshot/firewall.tf
+++ b/tf-managed/modules/daily-snapshot/firewall.tf
@@ -37,5 +37,12 @@ resource "digitalocean_firewall" "forest-firewall" {
     destination_addresses = var.destination_addresses
   }
 
+  # NTP
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "123"
+    destination_addresses = var.destination_addresses
+  }
+
   droplet_ids = [digitalocean_droplet.forest.id]
 }

--- a/tf-managed/modules/daily-snapshot/service/init.sh
+++ b/tf-managed/modules/daily-snapshot/service/init.sh
@@ -8,9 +8,14 @@ cloud-init status --wait
 # Setting DEBIAN_FRONTEND to ensure non-interactive operations for APT
 export DEBIAN_FRONTEND=noninteractive
 
+# https://www.digitalocean.com/community/tutorials/how-to-set-up-time-synchronization-on-ubuntu-20-04
+# We will install the NTP service, so we need to disable the `systemd-timesyncd`.
+# This is to prevent the two services from conflicting with one another.
+timedatectl set-ntp no
+
 # Using timeout to ensure the script retries if the APT servers are temporarily unavailable.
 timeout 10m bash -c 'until apt-get -qqq --yes update && \
- apt-get -qqq --yes install anacron ; do sleep 10; \
+ apt-get -qqq --yes install anacron ntp ; do sleep 10; \
 done'
 
 # Run new_relic and fail2ban scripts


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- this hopefully will resolve block from the future errors in snapshot service
```
 2024-03-18T15:47:08.892094Z  WARN forest_filecoin::chain_sync::chain_muxer: Skipping tipset with invalid block timestamp from the future, now_epoch: 1448349, epoch: 1448349, timestamp: 1710776850
```



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
