### PR TITLE
Parametrize forest tag

### DIFF
--- a/tf-managed/live/environments/dev/applications/forest-butterflynet/terragrunt.hcl
+++ b/tf-managed/live/environments/dev/applications/forest-butterflynet/terragrunt.hcl
@@ -13,4 +13,5 @@ inputs = {
   chain        = "butterflynet"
   droplet_size = "s-1vcpu-2gb-amd"
   service_name = "forest-butterflynet"
+  forest_tag   = "2024-03-25-44c3331-fat"
 }

--- a/tf-managed/live/environments/prod/applications/forest-butterflynet/terragrunt.hcl
+++ b/tf-managed/live/environments/prod/applications/forest-butterflynet/terragrunt.hcl
@@ -13,4 +13,5 @@ inputs = {
   chain        = "butterflynet"
   droplet_size = "s-1vcpu-2gb-amd"
   service_name = "forest-butterflynet"
+  forest_tag   = "2024-03-25-44c3331-fat"
 }

--- a/tf-managed/modules/forest-droplet/bootstrap.bash.tftpl
+++ b/tf-managed/modules/forest-droplet/bootstrap.bash.tftpl
@@ -60,7 +60,7 @@ sudo --user="${NEW_USER}" -- \
   --publish=6116:6116 \
   --publish=12345:12345 \
   --restart=always \
-  ghcr.io/chainsafe/forest:latest \
+  ghcr.io/chainsafe/forest:${FOREST_TAG} \
   --config=/home/"${NEW_USER}"/forest_data/config.toml \
   --encrypt-keystore false \
   --auto-download-snapshot \

--- a/tf-managed/modules/forest-droplet/main.tf
+++ b/tf-managed/modules/forest-droplet/main.tf
@@ -21,6 +21,7 @@ resource "local_sensitive_file" "bootstrap_script" {
       NEW_RELIC_API_KEY    = var.new_relic_api_key != null ? var.new_relic_api_key : ""
       NEW_RELIC_ACCOUNT_ID = var.new_relic_account_id != null ? var.new_relic_account_id : ""
       NEW_RELIC_REGION     = "EU"
+      FOREST_TAG           = var.forest_tag
     }
   )
 }

--- a/tf-managed/modules/forest-droplet/variable.tf
+++ b/tf-managed/modules/forest-droplet/variable.tf
@@ -32,3 +32,9 @@ variable "new_relic_account_id" {
   sensitive = true
   type      = string
 }
+
+# Tag of the Docker image to use for the Forest service
+variable "forest_tag" {
+  default = "latest-fat"
+  type    = string
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- parameterized Forest tag (use `latest-fat` by default) for Forest droplets,
- used recent Forest image for Butterflynet; it was reset on 25.03.2024.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
