### PR TITLE
use host network for filecoin nodes

### DIFF
--- a/tf-managed/modules/forest-droplet/bootstrap.bash.tftpl
+++ b/tf-managed/modules/forest-droplet/bootstrap.bash.tftpl
@@ -52,13 +52,10 @@ sudo --user="${NEW_USER}" -- docker network create forest
 sudo --user="${NEW_USER}" -- \
   docker run \
   --detach \
-  --network=forest \
   --name=forest-"${CHAIN}" \
   --env "FOREST_GC_TRIGGER_FACTOR=1.4" \
   --volume=/home/"${NEW_USER}"/forest_data:/home/"${NEW_USER}"/forest_data:z \
-  --publish=2345:2345 \
-  --publish=6116:6116 \
-  --publish=12345:12345 \
+  --network=host \
   --restart=always \
   ghcr.io/chainsafe/forest:${FOREST_TAG} \
   --config=/home/"${NEW_USER}"/forest_data/config.toml \
@@ -75,7 +72,6 @@ sudo --user="${NEW_USER}" -- \
   docker run \
   --detach \
   --name=watchtower \
-  --network=forest \
   --volume=/var/run/docker.sock:/var/run/docker.sock \
   --restart=unless-stopped \
   containrrr/watchtower \
@@ -132,7 +128,7 @@ EOF
   sudo --user="${NEW_USER}" -- \
     docker run \
     --detach \
-    --network=forest \
+    --network=host \
     --name=nri-prometheus \
     --env LICENSE_KEY="${NR_LICENSE_KEY}" \
     --volume=/home/"${NEW_USER}"/forest_data/config.yml:/config.yml \


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- without this, the node doesn't seem to be aware that it's running inside a container.
```
/ip4/127.0.0.1/tcp/12345/p2p/12D3KooWNt7gnq5nzTviWwtpjPD3d5NMMBu89RDpExDgU6x3p8QE
/ip4/172.18.0.2/tcp/12345/p2p/12D3KooWNt7gnq5nzTviWwtpjPD3d5NMMBu89RDpExDgU6x3p8QE
```

As an observed result, it doesn't seem to be crawlable, I guess it's related to the DHT table.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
