### PR TITLE
use available vps in sfo3 region for snapshots

### DIFF
--- a/tf-managed/live/environments/prod/applications/snapshot-service-2/terragrunt.hcl
+++ b/tf-managed/live/environments/prod/applications/snapshot-service-2/terragrunt.hcl
@@ -11,7 +11,7 @@ terraform {
 
 inputs = {
   name            = "forest-snapshot-2"
-  size            = "s-4vcpu-16gb-amd"
+  size            = "s-4vcpu-16gb-320gb-intel"
   r2_endpoint     = "https://2238a825c5aca59233eab1f221f7aefb.r2.cloudflarestorage.com/"
   forest_tag      = "v0.17.2-fat"
   snapshot_bucket = "forest-archive"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- fixes
```
│ Error: Error creating droplet: POST https://api.digitalocean.com/v2/droplets: 422 (request "94739105-b2bb-4bf4-90f3-e23974f4a74d") Size is not available in this region.
│
│   with digitalocean_droplet.forest,
│   on main.tf line 64, in resource "digitalocean_droplet" "forest":
│   64: resource "digitalocean_droplet" "forest" {
```

apparently this size is no longer available in this region, fallback to similar intel machine


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
