### PR TITLE
fix: not all releases start with `v`

### DIFF
--- a/scripts/mirror-actors/mirror_actors/__main__.py
+++ b/scripts/mirror-actors/mirror_actors/__main__.py
@@ -13,7 +13,7 @@ from slack_sdk.web import WebClient
 from github import Github
 
 GITHUB_REPO = "filecoin-project/builtin-actors"
-RELEASE_PATTERN = r'^v\d+\.\d+\.\d+.*$'
+RELEASE_PATTERN = r'^v?\d+\.\d+\.\d+.*$'
 
 # Initialize GitHub client
 github = Github()


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- there was a package that was use of tag `8.0.0-rc.1` which doesn't start with `v` but also needs to be mirrored. https://github.com/filecoin-project/builtin-actors/releases/tag/8.0.0-rc.1
 


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
