### PR TITLE
fix: replace the deleted 'last_validated_tipset_epoch' metric with 'head_epoch'

### DIFF
--- a/tf-managed/modules/sync-check/service/health_check.sh
+++ b/tf-managed/modules/sync-check/service/health_check.sh
@@ -57,7 +57,7 @@ echo "⏳ Waiting for Forest to start syncing (up to $timeout seconds)..."
 until [ -n "$tipset_start" ] || [ "$timeout" -le 0 ]
 do
   update_metrics
-  tipset_start="$(get_metric_value "last_validated_tipset_epoch")"
+  tipset_start="$(get_metric_value "head_epoch")"
   sleep 1
   timeout=$((timeout-1))
 done
@@ -76,7 +76,7 @@ sleep "$HEALTH_CHECK_DURATION_SECONDS"
 
 # Grab last synced tipset epoch
 update_metrics
-tipset_end="$(get_metric_value "last_validated_tipset_epoch")"
+tipset_end="$(get_metric_value "head_epoch")"
 
 if [ -z "$tipset_end" ]; then
   echo "❌ Did not manage to get sync status"


### PR DESCRIPTION

**Summary of changes**
Changes introduced in this pull request:
- the sync checker depends on a metric that I removed. It's better to use 'head_epoch'.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
