### PR TITLE
chore: remove R2 access key occurrences

### DIFF
--- a/.github/workflows/deploy-sync-check.yml
+++ b/.github/workflows/deploy-sync-check.yml
@@ -36,8 +36,6 @@ jobs:
           do_token: ${{ secrets.DO_TOKEN }}
           aws_access_key_id:  ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          r2_access_key: ${{ secrets.R2_ACCESS_KEY }}
-          r2_secret_key: ${{ secrets.R2_SECRET_KEY }}
           slack_token: ${{ secrets.SLACK_TOKEN }}
           working_directory: tf-managed/live/environments/prod/applications/sync-check
           service_name: Sync Check Service

--- a/composite-action/terragrunt/action.yml
+++ b/composite-action/terragrunt/action.yml
@@ -29,10 +29,6 @@ inputs:
     description: 'The New Relic Access Token'
   new_relic_account_id:
     description: 'The New Relic Platform Region'
-  r2_access_key:
-    description: 'CloudFlare R2 access key id'
-  r2_secret_key:
-    description: 'CloudFlare R2 private access key'
 
 runs:
   using: "composite"
@@ -85,8 +81,6 @@ runs:
         TF_VAR_digitalocean_token: ${{ inputs.do_token }}
         TF_VAR_AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}
         TF_VAR_AWS_SECRET_ACCESS_KEY: ${{ inputs.aws_secret_access_key }}
-        TF_VAR_R2_ACCESS_KEY: ${{ inputs.r2_access_key }}
-        TF_VAR_R2_SECRET_KEY: ${{ inputs.r2_secret_key }}
         TF_VAR_slack_token: ${{ inputs.slack_token }}
         TF_VAR_new_relic_api_key: ${{ inputs.new_relic_api_key }}
         TF_VAR_new_relic_account_id: ${{ inputs.new_relic_account_id }}
@@ -164,8 +158,6 @@ runs:
         TF_VAR_digitalocean_token: ${{ inputs.do_token }}
         TF_VAR_AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}
         TF_VAR_AWS_SECRET_ACCESS_KEY: ${{ inputs.aws_secret_access_key }}
-        TF_VAR_R2_ACCESS_KEY: ${{ inputs.r2_access_key }}
-        TF_VAR_R2_SECRET_KEY: ${{ inputs.r2_secret_key }}
         TF_VAR_slack_token: ${{ inputs.slack_token }}
         TF_VAR_new_relic_api_key: ${{ inputs.new_relic_api_key }}
         TF_VAR_new_relic_account_id: ${{ inputs.new_relic_account_id }}
@@ -179,8 +171,6 @@ runs:
         TF_VAR_digitalocean_token: ${{ inputs.do_token }}
         TF_VAR_AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}
         TF_VAR_AWS_SECRET_ACCESS_KEY: ${{ inputs.aws_secret_access_key }}
-        TF_VAR_R2_ACCESS_KEY: ${{ inputs.r2_access_key }}
-        TF_VAR_R2_SECRET_KEY: ${{ inputs.r2_secret_key }}
         TF_VAR_slack_token: ${{ inputs.slack_token }}
         TF_VAR_new_relic_api_key: ${{ inputs.new_relic_api_key }}
         TF_VAR_new_relic_account_id: ${{ inputs.new_relic_account_id }}

--- a/tf-managed/live/README.md
+++ b/tf-managed/live/README.md
@@ -80,10 +80,6 @@ export AWS_SECRET_ACCESS_KEY=
 # Required for services with Slack notifications
 export TF_VAR_slack_token=
 
-# Required for access to Cloudflare R2
-export TF_VAR_R2_ACCESS_KEY=
-export TF_VAR_R2_SECRET_KEY=
-
 # Required if NewRelic monitoring/alerting is enabled.
 export TF_VAR_new_relic_api_key=
 export TF_VAR_new_relic_account_id=


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- removed R2 access secrets occurrences (the one for mirroring actors is still there, which is scoped to the actors bucket).



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
