### PR TITLE
chore: cleanup stale GC configs

### DIFF
--- a/tf-managed/modules/forest-droplet/bootstrap.bash.tftpl
+++ b/tf-managed/modules/forest-droplet/bootstrap.bash.tftpl
@@ -53,7 +53,6 @@ sudo --user="${NEW_USER}" -- \
   docker run \
   --detach \
   --name=forest-"${CHAIN}" \
-  --env "FOREST_GC_TRIGGER_FACTOR=1.4" \
   --volume=/home/"${NEW_USER}"/forest_data:/home/"${NEW_USER}"/forest_data:z \
   --network=host \
   --restart=always \

--- a/tf-managed/modules/sync-check/service/docker-compose.yml
+++ b/tf-managed/modules/sync-check/service/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - '--save-token'
       - '/tmp/admin_token'
     environment:
-      FOREST_GC_TRIGGER_FACTOR: "1.4"
+      FOREST_SNAPSHOT_GC_INTERVAL_EPOCHS: "8640" # every 3 days
     restart: unless-stopped
     labels:
       com.centurylinklabs.watchtower.enable: true
@@ -51,7 +51,7 @@ services:
       - '--save-token'
       - '/tmp/admin_token'
     environment:
-      FOREST_GC_TRIGGER_FACTOR: "1.2"
+      FOREST_SNAPSHOT_GC_INTERVAL_EPOCHS: "8640" # every 3 days
     restart: unless-stopped
     labels:
       com.centurylinklabs.watchtower.enable: true


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- `FOREST_GC_TRIGGER_FACTOR` is no longer relevant
- set `FOREST_SNAPSHOT_GC_INTERVAL_EPOCHS` to `8640`(3 days) to avoid `Cleaning up sync check` job


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
