### PR TITLE
fix: run sync check with larger SSD

### DIFF
--- a/tf-managed/live/environments/prod/applications/sync-check/terragrunt.hcl
+++ b/tf-managed/live/environments/prod/applications/sync-check/terragrunt.hcl
@@ -11,5 +11,5 @@ terraform {
 
 inputs = {
   name = "sync-check"
-  size = "s-4vcpu-16gb-amd"
+  size = "s-4vcpu-16gb"
 }

--- a/tf-managed/modules/sync-check/service/sync_check_process.rb
+++ b/tf-managed/modules/sync-check/service/sync_check_process.rb
@@ -106,7 +106,7 @@ class SyncCheck
     loop do
       begin
         `docker image prune -f`
-        cleanup unless disk_usage < 0.85
+        cleanup unless disk_usage < 0.95
         start_services unless services_up?
       rescue StandardError => e
         report_error e


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- run sync check with larger SSD for running GC (84 $ / mon -> 96 $ / mon)

Previous: 200GiB https://pcr.cloud-mercato.com/providers/digitalocean/flavors/s-4vcpu-16gb-amd
Now: 320GiB https://pcr.cloud-mercato.com/providers/digitalocean/flavors/s-4vcpu-16gb-320gb-intel



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
