### PR TITLE
fix: cleanup old images after watchtower performs updates

### DIFF
--- a/tf-managed/modules/forest-droplet/bootstrap.bash.tftpl
+++ b/tf-managed/modules/forest-droplet/bootstrap.bash.tftpl
@@ -74,7 +74,7 @@ sudo --user="${NEW_USER}" -- \
   --volume=/var/run/docker.sock:/var/run/docker.sock \
   --restart=unless-stopped \
   containrrr/watchtower \
-  --include-stopped --revive-stopped --stop-timeout 120s --interval 600
+  --include-stopped --revive-stopped --stop-timeout 120s --interval 600 --cleanup
 
 # If new relic API key is provided, install the new relic agent
 if [ -n "${NEW_RELIC_API_KEY}" ] ; then

--- a/tf-managed/modules/sync-check/service/run_service.sh
+++ b/tf-managed/modules/sync-check/service/run_service.sh
@@ -31,7 +31,7 @@ docker run \
     -v /var/run/docker.sock:/var/run/docker.sock \
     --name watchtower \
     containrrr/watchtower \
-    --label-enable --include-stopped --revive-stopped --stop-timeout 120s --interval 600
+    --label-enable --include-stopped --revive-stopped --stop-timeout 120s --interval 600 --cleanup
 
 ## We need it to access the DATA_DIR regardless of the user.
 chmod 0777 /var/lib/docker/volumes/forest-data/_data


### PR DESCRIPTION
**Summary of changes**

Changes introduced in this pull request:
- add `--cleanup` to `watchtower`: https://containrrr.dev/watchtower/arguments/#cleanup to save disk space



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
