### PR TITLE
feat: build & publish `rpc-checks` docker image

### DIFF
--- a/.github/workflows/rpc-checks-image.yml
+++ b/.github/workflows/rpc-checks-image.yml
@@ -1,11 +1,9 @@
 name: rpc-checks image
 
 on:
-  pull_request:
-    paths:
-      - 'scripts/rpc-checks/**'
-      - '.github/workflows/rpc-checks-image.yml'
   push:
+    branches:
+      - main
     paths:
       - 'scripts/rpc-checks/**'
       - '.github/workflows/rpc-checks-image.yml'
@@ -24,9 +22,8 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Pull requests build only, to catch a broken Dockerfile before it lands.
       - name: Log in to GHCR
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -37,7 +34,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: scripts/rpc-checks
-          push: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: |
             ghcr.io/chainsafe/forest-rpc-checks:latest
             ghcr.io/chainsafe/forest-rpc-checks:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/rpc-checks-image.yml
+++ b/.github/workflows/rpc-checks-image.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/rpc-checks-image.yml
+++ b/.github/workflows/rpc-checks-image.yml
@@ -1,0 +1,43 @@
+name: rpc-checks image
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/rpc-checks/**'
+      - '.github/workflows/rpc-checks-image.yml'
+  push:
+    paths:
+      - 'scripts/rpc-checks/**'
+      - '.github/workflows/rpc-checks-image.yml'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Pull requests build only, to catch a broken Dockerfile before it lands.
+      - name: Log in to GHCR
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: scripts/rpc-checks
+          push: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/chainsafe/forest-rpc-checks:latest
+            ghcr.io/chainsafe/forest-rpc-checks:${{ github.sha }}

--- a/scripts/rpc-checks/.dockerignore
+++ b/scripts/rpc-checks/.dockerignore
@@ -2,3 +2,4 @@ vendor/
 .bundle/
 .gitignore
 README.md
+Dockerfile

--- a/scripts/rpc-checks/Dockerfile
+++ b/scripts/rpc-checks/Dockerfile
@@ -1,14 +1,14 @@
 # Build the native gem extensions in a throwaway stage so the runtime image
 # ships without a compiler toolchain.
-FROM ruby:4.0-slim AS gems
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
-    && rm -rf /var/lib/apt/lists/*
+FROM ruby:4.0-alpine AS gems
+RUN apk add --no-cache build-base
 WORKDIR /app
 ENV BUNDLE_FROZEN=true BUNDLE_PATH=/bundle
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
-FROM ruby:4.0-slim
+FROM ruby:4.0-alpine
+
 WORKDIR /app
 ENV BUNDLE_PATH=/bundle
 COPY --from=gems /bundle /bundle

--- a/scripts/rpc-checks/check_rpc.rb
+++ b/scripts/rpc-checks/check_rpc.rb
@@ -46,10 +46,6 @@ ARCHIVE_FILES = {
 
 def hex(num) = format('0x%x', num)
 
-# Known expected mismatches, dropped before comparing (remove as they get
-# fixed): logsBloom — Forest returns an all-ones placeholder for the
-# block-level bloom (PR #7156); accessList — the dataset normalizes the
-# field to [] on legacy txs where the node omits it (issue #7205).
 def norm_tx(txn) = txn.is_a?(Hash) ? txn.except('accessList') : txn
 
 def norm_txs(txs) = txs.map { norm_tx(it) }
@@ -57,7 +53,7 @@ def norm_txs(txs) = txs.map { norm_tx(it) }
 def norm_block(block)
   return block unless block.is_a?(Hash)
 
-  block.except('logsBloom').tap do |b|
+  block.dup.tap do |b|
     b['transactions'] = norm_txs(b['transactions']) if b['transactions'].is_a?(Array)
   end
 end

--- a/scripts/rpc-checks/check_rpc.rb
+++ b/scripts/rpc-checks/check_rpc.rb
@@ -46,6 +46,8 @@ ARCHIVE_FILES = {
 
 def hex(num) = format('0x%x', num)
 
+# Known expected mismatch, dropped before comparing (remove once fixed): Forest
+# omits accessList on legacy (type 0x0) txs, where the dataset emits [] (#7205).
 def norm_tx(txn) = txn.is_a?(Hash) ? txn.except('accessList') : txn
 
 def norm_txs(txs) = txs.map { norm_tx(it) }


### PR DESCRIPTION
**Summary of changes**

Changes introduced in this pull request:

1. Remove `.except('logsBloom')` from `check_rpc.rb`
2. Run image on `ruby:4.0-alpine` to reduce final image size
3. Add `.github/workflows/rpc-checks-image.yml` that builds & publish the image to `GHCR`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Ref: https://github.com/ChainSafe/forest/issues/7270


**Other information and links**
<!-- Add any other context about the pull request here. -->
N/A
<!-- Thank you 🔥 -->
