### PR TITLE
feat: multiarch docker build for `external-rpc-checks`

### DIFF
--- a/.github/workflows/rpc-checks-image.yml
+++ b/.github/workflows/rpc-checks-image.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Login to Github Packages
         if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v4
@@ -47,6 +53,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: scripts/rpc-checks
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Update `rpc-checks-image.yml` to target `linux/amd64`& `linux/arm64`, the former using QEMU so I dont need to add 2 jobs for each arch


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
N/A


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->
